### PR TITLE
feat(github): add issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,98 @@
+name: Bug Report
+description: Report a reproducible problem so we can fix it quickly.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please include enough detail for someone unfamiliar with the issue to reproduce it.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened and why this is a problem.
+      placeholder: A short summary of the bug and its impact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Provide exact steps so we can reproduce this bug.
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What should have happened.
+      placeholder: Expected result.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: What actually happened.
+      placeholder: Actual result, including errors if any.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: Choose the impact level of this bug.
+      options:
+        - Critical
+        - Major
+        - Minor
+        - Cosmetic
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser
+      description: Browser name and version.
+      placeholder: Chrome 122, Safari 17, Firefox 123
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: OS and version.
+      placeholder: macOS 14.3, Windows 11, Ubuntu 24.04
+    validations:
+      required: true
+
+  - type: input
+    id: screen-size
+    attributes:
+      label: Screen Size
+      description: Device and viewport size.
+      placeholder: 1440x900 (desktop), 390x844 (mobile)
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Drag and drop screenshots, videos, or logs here.
+      placeholder: Add visuals that show the bug.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions and Support
+    url: https://github.com/Farm-credit/stellar-app-os/discussions
+    about: Ask questions and discuss ideas before opening a formal issue.
+  - name: Security Vulnerability Report
+    url: https://github.com/Farm-credit/stellar-app-os/security/policy
+    about: Report sensitive security issues privately.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,70 @@
+name: Feature Request
+description: Propose a new capability with clear user value and acceptance criteria.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for new features. Focus on user value, scope, and clear completion criteria.
+
+  - type: textarea
+    id: user-story
+    attributes:
+      label: User Story
+      description: Use the format - As a [user], I want [feature] so that [benefit].
+      placeholder: As a ..., I want ..., so that ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem-context
+    attributes:
+      label: Problem Context
+      description: What problem are we solving and who is affected?
+      placeholder: Describe the current limitation and impact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the feature behavior and key workflows.
+      placeholder: Outline the expected functionality.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: Select the requested delivery priority.
+      options:
+        - P0 - Critical
+        - P1 - High
+        - P2 - Medium
+        - P3 - Low
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Check each item that is required for this feature to be complete.
+      options:
+        - label: The feature behavior is clearly defined for end users.
+        - label: Edge cases and error states are described.
+        - label: Success can be verified with testable outcomes.
+        - label: Dependencies, risks, or rollout notes are documented.
+
+  - type: textarea
+    id: design-mockups
+    attributes:
+      label: Design Mockups
+      description: Provide links, attachments, or notes for UX/UI designs.
+      placeholder: Figma links, screenshots, wireframes, or "N/A".
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,58 @@
+name: Task
+description: Track internal project work with complete context, scope, and execution details.
+title: "[Task]: "
+labels:
+  - task
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for planned internal work. Keep each section specific and actionable.
+
+  - type: textarea
+    id: context-impact
+    attributes:
+      label: Context & Impact
+      description: Why this task matters and what outcome it enables.
+      placeholder: Describe background, current pain, and expected impact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: List what is in scope and out of scope.
+      placeholder: Include boundaries and deliverables.
+    validations:
+      required: true
+
+  - type: textarea
+    id: implementation-guidelines
+    attributes:
+      label: Implementation Guidelines
+      description: Technical constraints, architecture notes, or coding requirements.
+      placeholder: Provide implementation direction and standards to follow.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Define testable completion criteria.
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+        - [ ] Criterion 3
+    validations:
+      required: true
+
+  - type: textarea
+    id: getting-started
+    attributes:
+      label: Getting Started
+      description: Initial setup and first implementation steps.
+      placeholder: Include setup commands, files to touch, and verification steps.
+    validations:
+      required: true


### PR DESCRIPTION
## Summary
  Add structured GitHub issue templates so bug reports, feature requests, and internal tasks are actionable from creation.

  ## What Was Implemented
  - Added `.github/ISSUE_TEMPLATE/bug_report.yml`
  - Added `.github/ISSUE_TEMPLATE/feature_request.yml`
  - Added `.github/ISSUE_TEMPLATE/task.yml`
  - Added `.github/ISSUE_TEMPLATE/config.yml`

  ## Implementation Details
  - Implemented GitHub **form-based** YAML templates.
  - Bug template includes: description, repro steps, expected vs actual behavior, environment, screenshots, severity.
  - Feature template includes: user story, problem context, proposed solution, acceptance criteria checklist, mockups, priority.
  - Task template includes: Context & Impact, Scope, Implementation Guidelines, Acceptance Criteria, Getting Started.
  - Auto-labels applied by template:
    - Bug: `bug`
    - Feature: `enhancement`
    - Task: `task`
  - `config.yml` enables blank issues and adds external contact links.

  ## How to Test
  1. Open `https://github.com/Farm-credit/stellar-app-os/issues/new/choose`
  2. Verify all three templates appear.
  3. Create a test issue from each template and confirm expected fields render.
  4. Submit each and confirm correct label auto-applies.
  5. Confirm blank issue option is available.

  Closes #108

  If you want, I can also draft the PR title and a one-line merge commit message.

 