### PR TITLE
feat(onboarding): add guided tour with restart settings

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,11 +4,12 @@ import { Text } from "@/components/atoms/Text";
 import { Badge } from "@/components/atoms/Badge";
 import { Counter } from "@/components/atoms/Counter";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/molecules/Card";
+import { OnboardingTour } from "@/components/organisms/OnboardingTour/OnboardingTour";
 
 export default function Home() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-8 p-8">
-      <div className="flex flex-col items-center gap-4 text-center">
+      <div data-tour-id="hero-section" className="flex flex-col items-center gap-4 text-center">
         <Badge variant="default">Powered by Stellar</Badge>
         <Text variant="h1">FarmCredit</Text>
         <Text variant="muted" className="max-w-md">
@@ -17,7 +18,7 @@ export default function Home() {
       </div>
 
       {/* Platform Stats */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 w-full max-w-4xl">
+      <div data-tour-id="stats-grid" className="grid grid-cols-1 sm:grid-cols-3 gap-6 w-full max-w-4xl">
         <div className="flex flex-col items-center gap-2 p-6 rounded-lg bg-muted/50">
           <Counter end={1234567} prefix="$" className="text-center" />
           <Text variant="muted" className="text-sm">
@@ -38,7 +39,7 @@ export default function Home() {
         </div>
       </div>
 
-      <Card className="w-full max-w-md">
+      <Card data-tour-id="get-started-card" className="w-full max-w-md">
         <CardHeader>
           <CardTitle>Get Started</CardTitle>
           <CardDescription>
@@ -46,17 +47,18 @@ export default function Home() {
           </CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-3">
-          <Button variant="default" size="lg" className="w-full">
+          <Button data-tour-id="connect-wallet-button" variant="default" size="lg" className="w-full">
             Connect Wallet
           </Button>
           <Button asChild variant="outline" size="lg" className="w-full">
             <Link href="/blog">Read our Blog</Link>
           </Button>
-          <Button asChild variant="outline" size="lg" className="w-full">
+          <Button data-tour-id="purchase-credits-button" asChild variant="outline" size="lg" className="w-full">
             <Link href="/credits/purchase">Purchase Carbon Credits</Link>
           </Button>
         </CardContent>
       </Card>
+      <OnboardingTour />
     </div>
   );
 }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/atoms/Button";
+import { Text } from "@/components/atoms/Text";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/molecules/Card";
+import {
+  hasCompletedOnboardingTour,
+  requestOnboardingTourRestart,
+} from "@/lib/onboardingTour";
+
+export default function SettingsPage(): React.ReactNode {
+  const router = useRouter();
+  const [tourCompleted, setTourCompleted] = useState(false);
+
+  useEffect(() => {
+    setTourCompleted(hasCompletedOnboardingTour());
+  }, []);
+
+  const restartTour = () => {
+    requestOnboardingTourRestart();
+    setTourCompleted(false);
+    router.push("/");
+  };
+
+  return (
+    <div className="container mx-auto max-w-3xl px-4 py-10">
+      <div className="mb-8">
+        <Text variant="h2" as="h1" className="mb-2">
+          Settings
+        </Text>
+        <Text variant="muted" as="p">
+          Manage onboarding and account preferences.
+        </Text>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Onboarding Tour</CardTitle>
+          <CardDescription>Restart the guided product tour at any time.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Text variant="small" as="p">
+            Status: {tourCompleted ? "Completed" : "Not completed"}
+          </Text>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Button stellar="primary" onClick={restartTour}>
+              Restart Tour
+            </Button>
+            <Button asChild variant="outline">
+              <Link href="/">Back to Home</Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/organisms/Footer/Footer.tsx
+++ b/components/organisms/Footer/Footer.tsx
@@ -24,6 +24,7 @@ const aboutSection: FooterSection = {
 const resourcesSection: FooterSection = {
   title: "Resources",
   links: [
+    { label: "Settings", href: "/settings" },
     { label: "API Documentation", href: "#api-docs" },
     { label: "Developer Guide", href: "#dev-guide" },
     { label: "Community", href: "#community" },

--- a/components/organisms/OnboardingTour/OnboardingTour.tsx
+++ b/components/organisms/OnboardingTour/OnboardingTour.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  consumeOnboardingTourRestartRequest,
+  hasCompletedOnboardingTour,
+  markOnboardingTourCompleted,
+  onboardingTourSteps,
+} from "@/lib/onboardingTour";
+import { Button } from "@/components/atoms/Button";
+import { Text } from "@/components/atoms/Text";
+
+interface FloatingPosition {
+  top: number;
+  left: number;
+}
+
+const DIALOG_MARGIN = 16;
+const STEP_SPACING = 14;
+const MOBILE_BREAKPOINT = 768;
+const SPOTLIGHT_PADDING = 8;
+
+export function OnboardingTour(): React.ReactNode {
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [targetRect, setTargetRect] = useState<DOMRect | null>(null);
+  const [dialogPosition, setDialogPosition] = useState<FloatingPosition>({
+    top: DIALOG_MARGIN,
+    left: DIALOG_MARGIN,
+  });
+
+  const totalSteps = onboardingTourSteps.length;
+  const currentStep = onboardingTourSteps[currentStepIndex];
+  const updateTargetRect = useCallback(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const element = document.querySelector<HTMLElement>(currentStep.target);
+    if (!element) {
+      setTargetRect(null);
+      return;
+    }
+
+    setTargetRect(element.getBoundingClientRect());
+  }, [currentStep.target, isOpen]);
+
+  useEffect(() => {
+    if (consumeOnboardingTourRestartRequest()) {
+      setCurrentStepIndex(0);
+      setIsOpen(true);
+      return;
+    }
+
+    if (!hasCompletedOnboardingTour()) {
+      setIsOpen(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const element = document.querySelector<HTMLElement>(currentStep.target);
+    if (!element) {
+      setTargetRect(null);
+      return;
+    }
+
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    element.scrollIntoView({
+      behavior: prefersReducedMotion ? "auto" : "smooth",
+      block: "center",
+      inline: "center",
+    });
+  }, [currentStep.target, isOpen]);
+
+  useEffect(() => {
+    updateTargetRect();
+
+    if (!isOpen) {
+      return;
+    }
+
+    const onViewportChange = () => {
+      updateTargetRect();
+    };
+
+    window.addEventListener("resize", onViewportChange);
+    window.addEventListener("scroll", onViewportChange, true);
+
+    return () => {
+      window.removeEventListener("resize", onViewportChange);
+      window.removeEventListener("scroll", onViewportChange, true);
+    };
+  }, [isOpen, updateTargetRect]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const dialog = dialogRef.current;
+    if (!dialog) {
+      return;
+    }
+
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+    const dialogWidth = dialog.offsetWidth;
+    const dialogHeight = dialog.offsetHeight;
+
+    if (viewportWidth < MOBILE_BREAKPOINT || !targetRect) {
+      setDialogPosition({
+        top: Math.max(DIALOG_MARGIN, viewportHeight - dialogHeight - DIALOG_MARGIN),
+        left: Math.max(DIALOG_MARGIN, (viewportWidth - dialogWidth) / 2),
+      });
+      return;
+    }
+
+    const proposedBottom = targetRect.bottom + STEP_SPACING;
+    const proposedTop = targetRect.top - dialogHeight - STEP_SPACING;
+    const fitsBelow = proposedBottom + dialogHeight <= viewportHeight - DIALOG_MARGIN;
+    const top = fitsBelow
+      ? proposedBottom
+      : Math.max(DIALOG_MARGIN, Math.min(proposedTop, viewportHeight - dialogHeight - DIALOG_MARGIN));
+
+    const centeredLeft = targetRect.left + targetRect.width / 2 - dialogWidth / 2;
+    const left = Math.max(DIALOG_MARGIN, Math.min(centeredLeft, viewportWidth - dialogWidth - DIALOG_MARGIN));
+
+    setDialogPosition({ top, left });
+  }, [currentStepIndex, isOpen, targetRect]);
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const handleComplete = useCallback(() => {
+    markOnboardingTourCompleted();
+    setIsOpen(false);
+  }, []);
+
+  const handleNext = useCallback(() => {
+    if (currentStepIndex >= totalSteps - 1) {
+      handleComplete();
+      return;
+    }
+
+    setCurrentStepIndex((previous) => previous + 1);
+  }, [currentStepIndex, handleComplete, totalSteps]);
+
+  const handleBack = useCallback(() => {
+    setCurrentStepIndex((previous) => Math.max(0, previous - 1));
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        handleClose();
+        return;
+      }
+
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        handleNext();
+        return;
+      }
+
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        handleBack();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [handleBack, handleClose, handleNext, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    dialogRef.current?.focus();
+  }, [currentStepIndex, isOpen]);
+
+  const spotlightStyle = useMemo(() => {
+    if (!targetRect) {
+      return undefined;
+    }
+
+    const top = Math.max(0, targetRect.top - SPOTLIGHT_PADDING);
+    const left = Math.max(0, targetRect.left - SPOTLIGHT_PADDING);
+    const width = Math.max(0, targetRect.width + SPOTLIGHT_PADDING * 2);
+    const height = Math.max(0, targetRect.height + SPOTLIGHT_PADDING * 2);
+
+    return {
+      top,
+      left,
+      width,
+      height,
+      boxShadow: "0 0 0 9999px rgba(2, 6, 23, 0.72)",
+    };
+  }, [targetRect]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        className="fixed inset-0 z-[999] bg-slate-950/45"
+        onClick={handleClose}
+        aria-label="Close onboarding tour"
+      />
+
+      {spotlightStyle ? (
+        <div
+          className="pointer-events-none fixed z-[1000] rounded-xl border-2 border-stellar-cyan transition-all duration-300"
+          style={spotlightStyle}
+          aria-hidden="true"
+        />
+      ) : null}
+
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="onboarding-tour-title"
+        aria-describedby="onboarding-tour-description"
+        tabIndex={-1}
+        className="fixed z-[1001] w-[min(24rem,calc(100vw-2rem))] rounded-xl border border-stellar-blue/35 bg-slate-900 p-4 text-slate-100 shadow-2xl"
+        style={{
+          top: dialogPosition.top,
+          left: dialogPosition.left,
+        }}
+      >
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <Text variant="small" className="text-slate-300">
+            Step {currentStepIndex + 1} of {totalSteps}
+          </Text>
+          <Button variant="ghost" size="sm" onClick={handleClose} className="text-slate-200 hover:text-white">
+            Skip tour
+          </Button>
+        </div>
+
+        <Text id="onboarding-tour-title" variant="h4" as="h2" className="mb-2 text-white">
+          {currentStep.title}
+        </Text>
+
+        <Text id="onboarding-tour-description" variant="body" as="p" className="mb-4 text-slate-200">
+          {currentStep.description}
+        </Text>
+
+        <div className="flex items-center justify-between gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleBack}
+            disabled={currentStepIndex === 0}
+            className="border-slate-500 text-slate-100 hover:bg-slate-800"
+          >
+            Back
+          </Button>
+
+          <Button size="sm" stellar="primary" onClick={handleNext}>
+            {currentStepIndex === totalSteps - 1 ? "Finish tour" : "Next"}
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/lib/onboardingTour.ts
+++ b/lib/onboardingTour.ts
@@ -1,0 +1,93 @@
+export const ONBOARDING_TOUR_COMPLETED_KEY = "farmcredit:onboarding-tour:completed";
+export const ONBOARDING_TOUR_FORCE_START_KEY = "farmcredit:onboarding-tour:force-start";
+
+export interface OnboardingTourStep {
+  id: string;
+  target: string;
+  title: string;
+  description: string;
+}
+
+export const onboardingTourSteps: ReadonlyArray<OnboardingTourStep> = [
+  {
+    id: "welcome",
+    target: '[data-tour-id="hero-section"]',
+    title: "Welcome to FarmCredit",
+    description:
+      "This home view gives you a quick read on platform health and where to start.",
+  },
+  {
+    id: "stats",
+    target: '[data-tour-id="stats-grid"]',
+    title: "Platform Metrics",
+    description:
+      "Track issued credit, active farmers, and repayment performance at a glance.",
+  },
+  {
+    id: "get-started",
+    target: '[data-tour-id="get-started-card"]',
+    title: "Get Started Actions",
+    description:
+      "The primary actions for wallet connection, reading product updates, and buying credits live here.",
+  },
+  {
+    id: "connect-wallet",
+    target: '[data-tour-id="connect-wallet-button"]',
+    title: "Connect Wallet",
+    description:
+      "Start by connecting your wallet to unlock personalized credit and payment flows.",
+  },
+  {
+    id: "purchase-credits",
+    target: '[data-tour-id="purchase-credits-button"]',
+    title: "Purchase Carbon Credits",
+    description:
+      "Use this path to buy carbon credits and manage your portfolio over time.",
+  },
+];
+
+export function hasCompletedOnboardingTour(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return window.localStorage.getItem(ONBOARDING_TOUR_COMPLETED_KEY) === "true";
+}
+
+export function markOnboardingTourCompleted(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.setItem(ONBOARDING_TOUR_COMPLETED_KEY, "true");
+}
+
+export function resetOnboardingTourCompletion(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.removeItem(ONBOARDING_TOUR_COMPLETED_KEY);
+}
+
+export function requestOnboardingTourRestart(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  resetOnboardingTourCompletion();
+  window.localStorage.setItem(ONBOARDING_TOUR_FORCE_START_KEY, "true");
+}
+
+export function consumeOnboardingTourRestartRequest(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const shouldRestart = window.localStorage.getItem(ONBOARDING_TOUR_FORCE_START_KEY) === "true";
+  if (shouldRestart) {
+    window.localStorage.removeItem(ONBOARDING_TOUR_FORCE_START_KEY);
+  }
+
+  return shouldRestart;
+}


### PR DESCRIPTION

  ## Summary
  Implemented an onboarding tour for first-time users with spotlight guidance, smooth step navigation, persistence, and restart
  support from Settings.

  ## What Was Implemented
  - Added reusable onboarding tour component:
    - `components/organisms/OnboardingTour/OnboardingTour.tsx`
  - Added onboarding state + step config utilities:
    - `lib/onboardingTour.ts`
  - Added Settings page with restart control:
    - `app/settings/page.tsx`
  - Integrated tour targets and tour mount on home page:
    - `app/page.tsx`
  - Added Settings link in footer for easy restart access:
    - `components/organisms/Footer/Footer.tsx`

  ## Implementation Details
  - Spotlight overlay highlights key home UI elements.
  - Step-by-step tooltip with `Back`, `Next`, and `Finish`.
  - `Skip tour` option available at all times.
  - Keyboard accessibility:
    - `Esc` closes
    - `ArrowRight` next
    - `ArrowLeft` back
  - Completion persisted in `localStorage` so completed users do not see it again.
  - Restart flow from `/settings` resets preference and relaunches tour.
  - Responsive dialog positioning for mobile/tablet/desktop.
  - TypeScript-safe implementation with no `any` types added.

  ## How to Test
  1. Open `/` as a first-time user (clear local storage key first if needed).
  2. Verify tour starts and highlights key elements.
  3. Move through steps and confirm smooth progression.
  4. Click `Skip tour` and confirm it closes immediately.
  5. Complete the tour and refresh `/`; confirm it does not show again.
  6. Go to `/settings`, click `Restart Tour`, confirm redirect to `/` and tour restarts.
  7. Check behavior on mobile/tablet/desktop viewport sizes.
  8. Verify keyboard navigation and dialog semantics.

  Closes #79

  Suggested PR title:
  feat(onboarding): build guided onboarding tour with persisted completion and settings restart
