### PR TITLE
Implement 30% replanting buffer fund allocation

### DIFF
--- a/app/api/transaction/build-donation/route.ts
+++ b/app/api/transaction/build-donation/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { buildDonationTransaction } from '@/lib/stellar/transaction';
+import { calculateDonationAllocation } from '@/lib/constants/donation';
 import type { BuildDonationTransactionRequest } from '@/lib/types/donation-payment';
 
 export async function POST(request: Request) {
@@ -16,8 +17,9 @@ export async function POST(request: Request) {
     }
 
     const result = await buildDonationTransaction(amount, walletPublicKey, network, idempotencyKey);
+    const allocation = calculateDonationAllocation(amount);
 
-    return NextResponse.json(result);
+    return NextResponse.json({ ...result, allocation });
   } catch (error) {
     console.error('Error building donation transaction:', error);
     const errorMessage = error instanceof Error ? error.message : 'Failed to build transaction';

--- a/components/organisms/DonationAmountStep/DonationAmountStep.tsx
+++ b/components/organisms/DonationAmountStep/DonationAmountStep.tsx
@@ -8,12 +8,14 @@ import { Input } from '@/components/atoms/Input';
 import { Badge } from '@/components/atoms/Badge';
 import { ProgressStepper } from '@/components/molecules/ProgressStepper/ProgressStepper';
 import { useDonationContext } from '@/contexts/DonationContext';
-import { Trees, Mountain, Leaf } from 'lucide-react';
+import { Trees, Mountain, Leaf, Sprout } from 'lucide-react';
 import {
   MINIMUM_DONATION,
   TREES_PER_DOLLAR,
   HECTARES_PER_DOLLAR,
   CO2_PER_DOLLAR,
+  REPLANTING_BUFFER_PERCENT,
+  calculateDonationAllocation,
   formatCurrency,
   formatNumber,
 } from '@/lib/constants/donation';
@@ -66,6 +68,8 @@ export function DonationAmountStep() {
 
   // Handle extremely large amounts (cap display at reasonable values)
   const safeAmount = Math.min(currentAmount, 1000000);
+
+  const allocation = calculateDonationAllocation(safeAmount);
 
   const impact = {
     trees: Math.round(safeAmount * TREES_PER_DOLLAR),
@@ -139,10 +143,11 @@ export function DonationAmountStep() {
                 onClick={() => handleQuickSelect(amount)}
                 variant={selectedAmount === amount && !isCustom ? 'default' : 'outline'}
                 size="lg"
-                className={`relative p-6 h-auto ${selectedAmount === amount && !isCustom
+                className={`relative p-6 h-auto ${
+                  selectedAmount === amount && !isCustom
                     ? 'border-stellar-blue bg-stellar-blue/10 text-stellar-blue hover:bg-stellar-blue/20'
                     : ''
-                  }`}
+                }`}
                 aria-pressed={selectedAmount === amount && !isCustom}
                 aria-label={`Select ${formatCurrency(amount)} donation`}
               >
@@ -163,10 +168,11 @@ export function DonationAmountStep() {
               onClick={handleCustomClick}
               variant={isCustom ? 'default' : 'outline'}
               size="lg"
-              className={`relative p-6 h-auto ${isCustom
+              className={`relative p-6 h-auto ${
+                isCustom
                   ? 'border-stellar-blue bg-stellar-blue/10 text-stellar-blue hover:bg-stellar-blue/20'
                   : ''
-                }`}
+              }`}
               aria-pressed={isCustom}
               aria-label="Enter custom donation amount"
             >
@@ -228,12 +234,14 @@ export function DonationAmountStep() {
               role="switch"
               aria-checked={isMonthly}
               aria-label="Make this a monthly recurring donation"
-              className={`relative w-12 h-6 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stellar-green focus:ring-offset-2 ${isMonthly ? 'bg-stellar-green' : 'bg-gray-300'
-                }`}
+              className={`relative w-12 h-6 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-stellar-green focus:ring-offset-2 ${
+                isMonthly ? 'bg-stellar-green' : 'bg-gray-300'
+              }`}
             >
               <span
-                className={`absolute top-1 left-1 w-4 h-4 bg-white rounded-full transition-transform ${isMonthly ? 'translate-x-6' : ''
-                  }`}
+                className={`absolute top-1 left-1 w-4 h-4 bg-white rounded-full transition-transform ${
+                  isMonthly ? 'translate-x-6' : ''
+                }`}
               />
             </button>
           </div>
@@ -323,6 +331,41 @@ export function DonationAmountStep() {
                 </div>
               </div>
             </div>
+
+            {/* Replanting Buffer Fund Breakdown */}
+            {safeAmount > 0 && (
+              <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 space-y-3">
+                <div className="flex items-center gap-2">
+                  <Sprout className="w-4 h-4 text-amber-600" aria-hidden="true" />
+                  <Text className="text-sm font-semibold text-amber-800">Donation Allocation</Text>
+                </div>
+                <div className="space-y-2">
+                  <div className="flex justify-between items-center">
+                    <Text className="text-sm text-amber-700">Tree planting (70%)</Text>
+                    <Text className="text-sm font-semibold text-amber-900">
+                      {formatCurrency(allocation.planting)}
+                    </Text>
+                  </div>
+                  <div className="flex justify-between items-center">
+                    <Text className="text-sm text-amber-700">
+                      Replanting buffer ({Math.round(REPLANTING_BUFFER_PERCENT * 100)}%)
+                    </Text>
+                    <Text className="text-sm font-semibold text-amber-900">
+                      {formatCurrency(allocation.buffer)}
+                    </Text>
+                  </div>
+                  <div className="border-t border-amber-200 pt-2 flex justify-between items-center">
+                    <Text className="text-sm font-semibold text-amber-800">Total</Text>
+                    <Text className="text-sm font-bold text-amber-900">
+                      {formatCurrency(allocation.total)}
+                    </Text>
+                  </div>
+                </div>
+                <Text className="text-xs text-amber-600">
+                  The buffer fund covers tree failures and ensures survival rate targets are met.
+                </Text>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/lib/constants/donation.ts
+++ b/lib/constants/donation.ts
@@ -3,6 +3,22 @@ export const TREES_PER_DOLLAR = 1;
 export const HECTARES_PER_DOLLAR = 0.018;
 export const CO2_PER_DOLLAR = 0.048;
 
+// 30% of each donation is allocated to the replanting buffer fund.
+// This pool covers tree failures and ensures survival rate targets are met.
+export const REPLANTING_BUFFER_PERCENT = 0.3;
+
+export interface DonationAllocation {
+  total: number;
+  planting: number; // 70% — direct tree planting
+  buffer: number; // 30% — replanting buffer fund
+}
+
+export function calculateDonationAllocation(amount: number): DonationAllocation {
+  const buffer = parseFloat((amount * REPLANTING_BUFFER_PERCENT).toFixed(7));
+  const planting = parseFloat((amount - buffer).toFixed(7));
+  return { total: amount, planting, buffer };
+}
+
 export function formatCurrency(amount: number): string {
   return new Intl.NumberFormat('en-US', {
     style: 'currency',

--- a/lib/stellar/transaction.ts
+++ b/lib/stellar/transaction.ts
@@ -2,6 +2,7 @@ import { Networks, TransactionBuilder, Asset, Operation, Memo } from '@stellar/s
 import { Horizon } from '@stellar/stellar-sdk';
 import type { NetworkType } from '@/lib/types/wallet';
 import type { CreditSelectionState } from '@/lib/types/carbon';
+import { calculateDonationAllocation } from '@/lib/constants/donation';
 
 const USDC_ISSUER_MAINNET = 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
 const USDC_ISSUER_TESTNET = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
@@ -125,6 +126,9 @@ export async function submitTransaction(
   return result.hash;
 }
 
+// Replanting buffer fund address — receives 30% of each donation
+const REPLANTING_BUFFER_ADDRESS = 'GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE62MFPXXXIAGKZ6YTDCXI';
+
 export async function buildDonationTransaction(
   amount: number,
   sourcePublicKey: string,
@@ -143,17 +147,29 @@ export async function buildDonationTransaction(
   const sourceAccount = await server.loadAccount(sourcePublicKey);
   const usdcAsset = getUsdcAsset(network);
 
-  const recipientAddress = 'GABEMKJNR4GK7M4FROGA7I7PG63N2CKE3EGDSBSISG56SVL2O3KRNDXA';
+  const plantingAddress = 'GABEMKJNR4GK7M4FROGA7I7PG63N2CKE3EGDSBSISG56SVL2O3KRNDXA';
+
+  // Split: 70% to planting, 30% to replanting buffer fund
+  const { planting, buffer } = calculateDonationAllocation(amount);
 
   const transaction = new TransactionBuilder(sourceAccount, {
     fee: '100',
     networkPassphrase,
   })
+    // 70% — direct tree planting
     .addOperation(
       Operation.payment({
-        destination: recipientAddress,
+        destination: plantingAddress,
         asset: usdcAsset,
-        amount: amount.toFixed(7),
+        amount: planting.toFixed(7),
+      })
+    )
+    // 30% — replanting buffer fund (covers tree failures, ensures survival targets)
+    .addOperation(
+      Operation.payment({
+        destination: REPLANTING_BUFFER_ADDRESS,
+        asset: usdcAsset,
+        amount: buffer.toFixed(7),
       })
     )
     .addMemo(Memo.text(`donate:${idempotencyKey.slice(0, 20)}`))

--- a/lib/types/donation-payment.ts
+++ b/lib/types/donation-payment.ts
@@ -35,4 +35,9 @@ export interface BuildDonationTransactionRequest {
 export interface BuildDonationTransactionResponse {
   transactionXdr: string;
   networkPassphrase: string;
+  allocation: {
+    total: number;
+    planting: number;
+    buffer: number;
+  };
 }


### PR DESCRIPTION
## Summary

Implements the replanting buffer fund per the cost breakdown spec. 30% of every 
donation is automatically split and routed to a dedicated replanting pool on-chain, 
covering tree failures and ensuring survival rate targets are met.

## Related Issue

this pr Closes #324 

## What Was Implemented

- [x] `REPLANTING_BUFFER_PERCENT` constant (0.3) added to `lib/constants/donation.ts`
- [x] `DonationAllocation` type and `calculateDonationAllocation()` helper added
- [x] `buildDonationTransaction` updated to build a two-operation Stellar transaction — 70% to planting address, 30% to replanting buffer fund address (both USDC)
- [x] `BuildDonationTransactionResponse` type extended with `allocation` field
- [x] `build-donation` API route returns allocation breakdown in response
- [x] `DonationAmountStep` impact panel shows live donation allocation breakdown (planting vs. buffer) updating in real-time

## Implementation Details

The split happens at the Stellar transaction level — a single transaction contains 
two `payment` operations so both transfers are atomic. The `calculateDonationAllocation` 
helper uses `toFixed(7)` precision to match Stellar's 7 decimal place requirement and 
avoid floating point drift.

<!-- REQUIRED: attach screen recording -->

## How to Test

1. Checkout `feat/replanting-buffer-fund`
2. Run `pnpm dev`
3. Navigate to `/donate`
4. Select any donation amount — the impact panel should show the allocation breakdown card (70% planting / 30% buffer)
5. Proceed through to payment with a Stellar wallet — inspect the signed transaction to confirm two payment operations
