### PR TITLE
Feat/[Smart Contract] Soroban escrow contract - 75/25 milestone payment logic

### DIFF
--- a/PR_NULLIFIER_REGISTRY.md
+++ b/PR_NULLIFIER_REGISTRY.md
@@ -1,0 +1,50 @@
+# PR: On-Chain Nullifier Registry (Soroban)
+
+Closes #308
+
+## Summary
+
+Implements a Soroban smart contract that acts as an on-chain nullifier registry to prevent double-counting of tree carbon credits. Each tree registration produces a unique cryptographic commitment derived from GPS coordinates, timestamp, and farmer ID. Once a commitment is stored on-chain, any attempt to register the same tree again is rejected at the contract level.
+
+## What Changed
+
+- `contracts/nullifier-registry/src/lib.rs` — Soroban contract with:
+  - `initialize(admin)` — one-time setup
+  - `compute_commitment(input)` — deterministic SHA-256 hash of `gps + timestamp + farmer_id`
+  - `register(input)` — stores commitment, requires farmer auth, panics on duplicate
+  - `is_registered(commitment)` — read-only nullifier check
+  - `get_entry(commitment)` — returns full `NullifierEntry` (farmer, timestamp, commitment)
+- `contracts/nullifier-registry/Cargo.toml` — crate config targeting `cdylib` for Wasm
+- `contracts/Cargo.toml` — workspace root for all Soroban contracts
+
+## How It Works
+
+```
+commitment = SHA-256( gps_xdr | timestamp_be_bytes | farmer_id_xdr )
+```
+
+On `register`:
+1. Farmer signs the transaction (auth required)
+2. Contract computes the commitment
+3. Checks persistent storage — if key exists → panic (double-count rejected)
+4. Stores `NullifierEntry` and emits a `register` event for indexers
+
+## Tests
+
+Four unit tests using `soroban-sdk` testutils:
+- Happy path: register + lookup
+- Double registration rejected (expected panic)
+- Different inputs → different commitments
+- Deterministic commitment computation
+
+## How to Build & Test
+
+```bash
+cd contracts
+cargo test
+cargo build --release --target wasm32-unknown-unknown
+```
+
+## Related
+
+- Closes #308 — Prevent double-counting of tree carbon credits

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["nullifier-registry"]
+resolver = "2"

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["nullifier-registry", "escrow-milestone"]
+members = ["nullifier-registry", "escrow-milestone", "tree-escrow"]
 resolver = "2"

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["nullifier-registry"]
+members = ["nullifier-registry", "escrow-milestone"]
 resolver = "2"

--- a/contracts/escrow-milestone/Cargo.toml
+++ b/contracts/escrow-milestone/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "escrow-milestone"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { version = "21.0.0", features = ["alloc"] }
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils", "alloc"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/escrow-milestone/src/lib.rs
+++ b/contracts/escrow-milestone/src/lib.rs
@@ -1,0 +1,330 @@
+#![no_std]
+
+//! Escrow Milestone Release Contract — Closes #314
+//!
+//! Flow:
+//!   1. Funder deposits XLM/token into escrow via `deposit()`
+//!   2. Verifier (oracle/admin) calls `verify_milestone()` after GPS + photo check
+//!   3. Contract instantly releases 75% to the farmer's Stellar wallet
+//!   4. Remaining 25% stays locked until final milestone or dispute resolution
+
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, token, Address, Env,
+};
+
+// ── Storage keys ──────────────────────────────────────────────────────────────
+const ADMIN: &str    = "ADMIN";
+const ESCROW: &str   = "ESCROW";
+
+/// Percentage released on first milestone verification (basis points: 7500 = 75%)
+const MILESTONE_1_BPS: i128 = 7500;
+const BPS_DENOM: i128       = 10_000;
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum EscrowStatus {
+    Funded,
+    Milestone1Released,
+    Completed,
+    Refunded,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct EscrowState {
+    pub farmer:        Address,
+    pub funder:        Address,
+    pub token:         Address,
+    pub total_amount:  i128,
+    pub released:      i128,
+    pub status:        EscrowStatus,
+    pub verification_hash: Option<soroban_sdk::BytesN<32>>,
+}
+
+#[contract]
+pub struct EscrowMilestone;
+
+#[contractimpl]
+impl EscrowMilestone {
+    /// One-time init — sets the admin/verifier address.
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&symbol_short!("ADMIN")) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&symbol_short!("ADMIN"), &admin);
+    }
+
+    /// Funder deposits `amount` of `token` into escrow for `farmer`.
+    /// Creates a new escrow record keyed by farmer address.
+    pub fn deposit(
+        env: Env,
+        funder: Address,
+        farmer: Address,
+        token: Address,
+        amount: i128,
+    ) {
+        funder.require_auth();
+
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+
+        // Reject if escrow already active for this farmer
+        let key = Self::escrow_key(&env, &farmer);
+        if env.storage().persistent().has(&key) {
+            panic!("active escrow already exists for this farmer");
+        }
+
+        // Pull funds from funder into contract
+        let token_client = token::Client::new(&env, &token);
+        token_client.transfer(&funder, &env.current_contract_address(), &amount);
+
+        let state = EscrowState {
+            farmer:            farmer.clone(),
+            funder,
+            token,
+            total_amount:      amount,
+            released:          0,
+            status:            EscrowStatus::Funded,
+            verification_hash: None,
+        };
+
+        env.storage().persistent().set(&key, &state);
+
+        env.events().publish(
+            (symbol_short!("deposit"), farmer),
+            amount,
+        );
+    }
+
+    /// Called by the admin/verifier after GPS + photo validation passes.
+    /// Releases 75% of escrowed funds instantly to the farmer wallet.
+    /// `verification_hash` is the SHA-256 of the submitted GPS + photo proof.
+    pub fn verify_milestone(
+        env: Env,
+        farmer: Address,
+        verification_hash: soroban_sdk::BytesN<32>,
+    ) {
+        Self::require_admin(&env);
+
+        let key = Self::escrow_key(&env, &farmer);
+        let mut state: EscrowState = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("no escrow found for farmer");
+
+        if state.status != EscrowStatus::Funded {
+            panic!("milestone already processed or escrow not in funded state");
+        }
+
+        // Calculate 75% release
+        let release_amount = (state.total_amount * MILESTONE_1_BPS) / BPS_DENOM;
+
+        // Transfer to farmer
+        let token_client = token::Client::new(&env, &state.token);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &state.farmer,
+            &release_amount,
+        );
+
+        state.released          = release_amount;
+        state.status            = EscrowStatus::Milestone1Released;
+        state.verification_hash = Some(verification_hash.clone());
+
+        env.storage().persistent().set(&key, &state);
+
+        env.events().publish(
+            (symbol_short!("m1release"), farmer),
+            release_amount,
+        );
+    }
+
+    /// Release remaining 25% after final milestone — called by admin.
+    pub fn release_remainder(env: Env, farmer: Address) {
+        Self::require_admin(&env);
+
+        let key = Self::escrow_key(&env, &farmer);
+        let mut state: EscrowState = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("no escrow found for farmer");
+
+        if state.status != EscrowStatus::Milestone1Released {
+            panic!("first milestone not yet verified");
+        }
+
+        let remainder = state.total_amount - state.released;
+        if remainder <= 0 {
+            panic!("nothing left to release");
+        }
+
+        let token_client = token::Client::new(&env, &state.token);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &state.farmer,
+            &remainder,
+        );
+
+        state.released += remainder;
+        state.status    = EscrowStatus::Completed;
+
+        env.storage().persistent().set(&key, &state);
+
+        env.events().publish(
+            (symbol_short!("complete"), farmer),
+            remainder,
+        );
+    }
+
+    /// Refund full amount to funder — only before any milestone is verified.
+    pub fn refund(env: Env, farmer: Address) {
+        Self::require_admin(&env);
+
+        let key = Self::escrow_key(&env, &farmer);
+        let mut state: EscrowState = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("no escrow found for farmer");
+
+        if state.status != EscrowStatus::Funded {
+            panic!("cannot refund after milestone release");
+        }
+
+        let token_client = token::Client::new(&env, &state.token);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &state.funder,
+            &state.total_amount,
+        );
+
+        state.status = EscrowStatus::Refunded;
+        env.storage().persistent().set(&key, &state);
+
+        env.events().publish(
+            (symbol_short!("refund"), farmer),
+            state.total_amount,
+        );
+    }
+
+    /// Read escrow state for a farmer.
+    pub fn get_escrow(env: Env, farmer: Address) -> Option<EscrowState> {
+        env.storage().persistent().get(&Self::escrow_key(&env, &farmer))
+    }
+
+    // ── internal ──────────────────────────────────────────────────────────────
+
+    fn escrow_key(env: &Env, farmer: &Address) -> soroban_sdk::Val {
+        (symbol_short!("ESCROW"), farmer.clone()).into_val(env)
+    }
+
+    fn require_admin(env: &Env) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("ADMIN"))
+            .expect("contract not initialized");
+        admin.require_auth();
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{
+        testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation},
+        token, Address, BytesN, Env,
+    };
+
+    fn setup() -> (Env, Address, Address, Address, Address, EscrowMilestoneClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, EscrowMilestone);
+        let client      = EscrowMilestoneClient::new(&env, &contract_id);
+
+        let admin  = Address::generate(&env);
+        let funder = Address::generate(&env);
+        let farmer = Address::generate(&env);
+
+        // Deploy a test token
+        let token_id     = env.register_stellar_asset_contract(admin.clone());
+        let token_admin  = token::StellarAssetClient::new(&env, &token_id);
+        token_admin.mint(&funder, &10_000);
+
+        client.initialize(&admin);
+
+        (env, admin, funder, farmer, token_id, client)
+    }
+
+    fn dummy_hash(env: &Env) -> BytesN<32> {
+        BytesN::from_array(env, &[1u8; 32])
+    }
+
+    #[test]
+    fn test_deposit_and_verify_milestone() {
+        let (env, _admin, funder, farmer, token, client) = setup();
+
+        client.deposit(&funder, &farmer, &token, &10_000);
+
+        let state = client.get_escrow(&farmer).unwrap();
+        assert_eq!(state.total_amount, 10_000);
+        assert_eq!(state.status, EscrowStatus::Funded);
+
+        client.verify_milestone(&farmer, &dummy_hash(&env));
+
+        let state = client.get_escrow(&farmer).unwrap();
+        // 75% of 10_000 = 7_500 released
+        assert_eq!(state.released, 7_500);
+        assert_eq!(state.status, EscrowStatus::Milestone1Released);
+    }
+
+    #[test]
+    fn test_release_remainder() {
+        let (env, _admin, funder, farmer, token, client) = setup();
+
+        client.deposit(&funder, &farmer, &token, &10_000);
+        client.verify_milestone(&farmer, &dummy_hash(&env));
+        client.release_remainder(&farmer);
+
+        let state = client.get_escrow(&farmer).unwrap();
+        assert_eq!(state.released, 10_000);
+        assert_eq!(state.status, EscrowStatus::Completed);
+    }
+
+    #[test]
+    #[should_panic(expected = "milestone already processed")]
+    fn test_double_verify_rejected() {
+        let (env, _admin, funder, farmer, token, client) = setup();
+
+        client.deposit(&funder, &farmer, &token, &10_000);
+        client.verify_milestone(&farmer, &dummy_hash(&env));
+        client.verify_milestone(&farmer, &dummy_hash(&env)); // must panic
+    }
+
+    #[test]
+    fn test_refund_before_milestone() {
+        let (_env, _admin, funder, farmer, token, client) = setup();
+
+        client.deposit(&funder, &farmer, &token, &10_000);
+        client.refund(&farmer);
+
+        let state = client.get_escrow(&farmer).unwrap();
+        assert_eq!(state.status, EscrowStatus::Refunded);
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot refund after milestone release")]
+    fn test_refund_after_milestone_rejected() {
+        let (env, _admin, funder, farmer, token, client) = setup();
+
+        client.deposit(&funder, &farmer, &token, &10_000);
+        client.verify_milestone(&farmer, &dummy_hash(&env));
+        client.refund(&farmer); // must panic
+    }
+}

--- a/contracts/nullifier-registry/Cargo.toml
+++ b/contracts/nullifier-registry/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "nullifier-registry"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { version = "21.0.0", features = ["alloc"] }
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils", "alloc"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/nullifier-registry/src/lib.rs
+++ b/contracts/nullifier-registry/src/lib.rs
@@ -1,0 +1,188 @@
+#![no_std]
+
+use soroban_sdk::{
+    contract, contractimpl, contracttype, crypto::Hash, symbol_short, vec, Address, Bytes,
+    BytesN, Env, String,
+};
+
+// Storage key namespace
+const NULLIFIER: &str = "NULL";
+const ADMIN: &str = "ADMIN";
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct TreeCommitmentInput {
+    /// GPS coordinates as a string e.g. "-1.2345,36.8219"
+    pub gps: String,
+    /// Unix timestamp (seconds)
+    pub timestamp: u64,
+    /// Farmer's Stellar account address
+    pub farmer_id: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct NullifierEntry {
+    pub commitment: BytesN<32>,
+    pub farmer_id: Address,
+    pub registered_at: u64,
+}
+
+#[contract]
+pub struct NullifierRegistry;
+
+#[contractimpl]
+impl NullifierRegistry {
+    /// Initialize the contract with an admin address.
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&symbol_short!("ADMIN")) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&symbol_short!("ADMIN"), &admin);
+    }
+
+    /// Compute a SHA-256 commitment from GPS + timestamp + farmer_id.
+    /// Returns the 32-byte hash.
+    pub fn compute_commitment(env: Env, input: TreeCommitmentInput) -> BytesN<32> {
+        Self::_compute_commitment(&env, &input)
+    }
+
+    /// Register a tree commitment on-chain.
+    /// Panics if the commitment already exists (double-count prevention).
+    pub fn register(env: Env, input: TreeCommitmentInput) -> BytesN<32> {
+        // Caller must be the farmer themselves
+        input.farmer_id.require_auth();
+
+        let commitment = Self::_compute_commitment(&env, &input);
+
+        // Reject if already registered — nullifier check
+        if env
+            .storage()
+            .persistent()
+            .has(&commitment)
+        {
+            panic!("commitment already registered: double-counting rejected");
+        }
+
+        let entry = NullifierEntry {
+            commitment: commitment.clone(),
+            farmer_id: input.farmer_id.clone(),
+            registered_at: env.ledger().timestamp(),
+        };
+
+        env.storage().persistent().set(&commitment, &entry);
+
+        // Emit event for indexers
+        env.events().publish(
+            (symbol_short!("register"), input.farmer_id),
+            commitment.clone(),
+        );
+
+        commitment
+    }
+
+    /// Check whether a commitment is already in the registry.
+    pub fn is_registered(env: Env, commitment: BytesN<32>) -> bool {
+        env.storage().persistent().has(&commitment)
+    }
+
+    /// Fetch the full entry for a commitment (returns None if not found).
+    pub fn get_entry(env: Env, commitment: BytesN<32>) -> Option<NullifierEntry> {
+        env.storage().persistent().get(&commitment)
+    }
+
+    // ── internal ──────────────────────────────────────────────────────────────
+
+    fn _compute_commitment(env: &Env, input: &TreeCommitmentInput) -> BytesN<32> {
+        // Encode: gps_bytes | timestamp_be_8_bytes | farmer_id_bytes
+        let gps_bytes = input.gps.to_xdr(env);
+        let ts_bytes = input.timestamp.to_be_bytes();
+        let farmer_bytes = input.farmer_id.to_xdr(env);
+
+        let mut preimage = Bytes::new(env);
+        preimage.append(&gps_bytes);
+        preimage.extend_from_array(&ts_bytes);
+        preimage.append(&farmer_bytes);
+
+        env.crypto().sha256(&preimage)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+    fn setup() -> (Env, Address, NullifierRegistryClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, NullifierRegistry);
+        let client = NullifierRegistryClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+        (env, admin, client)
+    }
+
+    fn sample_input(env: &Env, farmer: &Address) -> TreeCommitmentInput {
+        TreeCommitmentInput {
+            gps: String::from_str(env, "-1.2345,36.8219"),
+            timestamp: 1_700_000_000u64,
+            farmer_id: farmer.clone(),
+        }
+    }
+
+    #[test]
+    fn test_register_and_lookup() {
+        let (env, _, client) = setup();
+        let farmer = Address::generate(&env);
+        let input = sample_input(&env, &farmer);
+
+        let commitment = client.register(&input);
+        assert!(client.is_registered(&commitment));
+
+        let entry = client.get_entry(&commitment).unwrap();
+        assert_eq!(entry.farmer_id, farmer);
+    }
+
+    #[test]
+    #[should_panic(expected = "commitment already registered")]
+    fn test_double_registration_rejected() {
+        let (env, _, client) = setup();
+        let farmer = Address::generate(&env);
+        let input = sample_input(&env, &farmer);
+
+        client.register(&input);
+        // Second call with identical input must panic
+        client.register(&input);
+    }
+
+    #[test]
+    fn test_different_inputs_produce_different_commitments() {
+        let (env, _, client) = setup();
+        let farmer = Address::generate(&env);
+
+        let input1 = sample_input(&env, &farmer);
+        let input2 = TreeCommitmentInput {
+            gps: String::from_str(&env, "-1.9999,36.0000"),
+            timestamp: 1_700_000_001u64,
+            farmer_id: farmer.clone(),
+        };
+
+        let c1 = client.register(&input1);
+        let c2 = client.register(&input2);
+        assert_ne!(c1, c2);
+    }
+
+    #[test]
+    fn test_compute_commitment_is_deterministic() {
+        let (env, _, client) = setup();
+        let farmer = Address::generate(&env);
+        let input = sample_input(&env, &farmer);
+
+        let c1 = client.compute_commitment(&input);
+        let c2 = client.compute_commitment(&input);
+        assert_eq!(c1, c2);
+    }
+}

--- a/contracts/tree-escrow/Cargo.toml
+++ b/contracts/tree-escrow/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "tree-escrow"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { version = "21.0.0", features = ["alloc"] }
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils", "alloc"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/tree-escrow/src/lib.rs
+++ b/contracts/tree-escrow/src/lib.rs
@@ -1,0 +1,321 @@
+#![no_std]
+
+//! Tree Escrow Contract — Closes #310
+//!
+//! Holds donor funds and releases them in two tranches:
+//!   • Tranche 1 (75%) — released on verified planting (GPS + photo proof)
+//!   • Tranche 2 (25%) — released after 6-month survival verification
+//!
+//! State machine:
+//!   Funded → Planted (75% out) → Survived (25% out, Completed)
+//!                              ↘ Disputed / Refunded
+
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env,
+};
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/// 75% in basis points
+const TRANCHE_1_BPS: i128 = 7_500;
+/// 25% in basis points
+const TRANCHE_2_BPS: i128 = 2_500;
+const BPS_DENOM: i128     = 10_000;
+
+/// 6 months in seconds (approx 26 weeks)
+const SIX_MONTHS_SECS: u64 = 60 * 60 * 24 * 7 * 26;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum EscrowStatus {
+    /// Funds deposited, awaiting planting proof
+    Funded,
+    /// Planting verified, 75% released — awaiting 6-month survival check
+    Planted,
+    /// Survival verified, 25% released — fully complete
+    Completed,
+    /// Refunded to donor (only before Planted)
+    Refunded,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct EscrowRecord {
+    pub donor:              Address,
+    pub farmer:             Address,
+    pub token:              Address,
+    pub total_amount:       i128,
+    pub released:           i128,
+    pub status:             EscrowStatus,
+    /// Ledger timestamp when planting was verified
+    pub planted_at:         Option<u64>,
+    /// SHA-256 of GPS + photo proof submitted at planting
+    pub planting_proof:     Option<BytesN<32>>,
+    /// SHA-256 of GPS + photo proof submitted at survival check
+    pub survival_proof:     Option<BytesN<32>>,
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct TreeEscrow;
+
+#[contractimpl]
+impl TreeEscrow {
+    /// One-time initialisation — sets the verifier/admin address.
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&symbol_short!("ADMIN")) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&symbol_short!("ADMIN"), &admin);
+    }
+
+    /// Donor deposits `amount` of `token` into escrow for `farmer`.
+    pub fn deposit(
+        env: Env,
+        donor: Address,
+        farmer: Address,
+        token: Address,
+        amount: i128,
+    ) {
+        donor.require_auth();
+
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+
+        let key = Self::record_key(&env, &farmer);
+        if env.storage().persistent().has(&key) {
+            panic!("active escrow already exists for this farmer");
+        }
+
+        // Pull funds from donor into contract
+        token::Client::new(&env, &token)
+            .transfer(&donor, &env.current_contract_address(), &amount);
+
+        env.storage().persistent().set(&key, &EscrowRecord {
+            donor:          donor.clone(),
+            farmer:         farmer.clone(),
+            token,
+            total_amount:   amount,
+            released:       0,
+            status:         EscrowStatus::Funded,
+            planted_at:     None,
+            planting_proof: None,
+            survival_proof: None,
+        });
+
+        env.events().publish((symbol_short!("deposit"), farmer), amount);
+    }
+
+    /// Verifier calls this after GPS + photo proof of planting is validated.
+    /// Releases 75% of escrowed funds instantly to the farmer.
+    pub fn verify_planting(
+        env: Env,
+        farmer: Address,
+        proof_hash: BytesN<32>,
+    ) {
+        Self::require_admin(&env);
+
+        let key = Self::record_key(&env, &farmer);
+        let mut rec: EscrowRecord = env.storage().persistent()
+            .get(&key).expect("no escrow for farmer");
+
+        if rec.status != EscrowStatus::Funded {
+            panic!("planting already verified or escrow not active");
+        }
+
+        let tranche1 = (rec.total_amount * TRANCHE_1_BPS) / BPS_DENOM;
+
+        token::Client::new(&env, &rec.token)
+            .transfer(&env.current_contract_address(), &rec.farmer, &tranche1);
+
+        rec.released       += tranche1;
+        rec.status          = EscrowStatus::Planted;
+        rec.planted_at      = Some(env.ledger().timestamp());
+        rec.planting_proof  = Some(proof_hash.clone());
+
+        env.storage().persistent().set(&key, &rec);
+
+        env.events().publish((symbol_short!("planted"), farmer), tranche1);
+    }
+
+    /// Verifier calls this after 6-month survival check passes.
+    /// Releases remaining 25% to the farmer.
+    /// Enforces that at least 6 months have elapsed since planting verification.
+    pub fn verify_survival(
+        env: Env,
+        farmer: Address,
+        proof_hash: BytesN<32>,
+    ) {
+        Self::require_admin(&env);
+
+        let key = Self::record_key(&env, &farmer);
+        let mut rec: EscrowRecord = env.storage().persistent()
+            .get(&key).expect("no escrow for farmer");
+
+        if rec.status != EscrowStatus::Planted {
+            panic!("planting not yet verified");
+        }
+
+        // Enforce 6-month lock
+        let planted_at = rec.planted_at.expect("planted_at missing");
+        let now        = env.ledger().timestamp();
+        if now < planted_at + SIX_MONTHS_SECS {
+            panic!("6-month survival period not yet elapsed");
+        }
+
+        let tranche2 = rec.total_amount - rec.released;
+        if tranche2 <= 0 {
+            panic!("nothing left to release");
+        }
+
+        token::Client::new(&env, &rec.token)
+            .transfer(&env.current_contract_address(), &rec.farmer, &tranche2);
+
+        rec.released      += tranche2;
+        rec.status         = EscrowStatus::Completed;
+        rec.survival_proof = Some(proof_hash);
+
+        env.storage().persistent().set(&key, &rec);
+
+        env.events().publish((symbol_short!("survived"), farmer), tranche2);
+    }
+
+    /// Refund full amount to donor — only allowed before planting is verified.
+    pub fn refund(env: Env, farmer: Address) {
+        Self::require_admin(&env);
+
+        let key = Self::record_key(&env, &farmer);
+        let mut rec: EscrowRecord = env.storage().persistent()
+            .get(&key).expect("no escrow for farmer");
+
+        if rec.status != EscrowStatus::Funded {
+            panic!("cannot refund after planting has been verified");
+        }
+
+        token::Client::new(&env, &rec.token)
+            .transfer(&env.current_contract_address(), &rec.donor, &rec.total_amount);
+
+        rec.status = EscrowStatus::Refunded;
+        env.storage().persistent().set(&key, &rec);
+
+        env.events().publish((symbol_short!("refund"), farmer), rec.total_amount);
+    }
+
+    /// Read escrow record for a farmer.
+    pub fn get_record(env: Env, farmer: Address) -> Option<EscrowRecord> {
+        env.storage().persistent().get(&Self::record_key(&env, &farmer))
+    }
+
+    // ── internal ──────────────────────────────────────────────────────────────
+
+    fn record_key(env: &Env, farmer: &Address) -> soroban_sdk::Val {
+        (symbol_short!("ESC"), farmer.clone()).into_val(env)
+    }
+
+    fn require_admin(env: &Env) {
+        let admin: Address = env.storage().instance()
+            .get(&symbol_short!("ADMIN"))
+            .expect("contract not initialized");
+        admin.require_auth();
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, token, Address, BytesN, Env};
+
+    fn setup() -> (Env, Address, Address, Address, Address, TreeEscrowClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, TreeEscrow);
+        let client      = TreeEscrowClient::new(&env, &contract_id);
+
+        let admin  = Address::generate(&env);
+        let donor  = Address::generate(&env);
+        let farmer = Address::generate(&env);
+
+        let token_id = env.register_stellar_asset_contract(admin.clone());
+        token::StellarAssetClient::new(&env, &token_id).mint(&donor, &10_000);
+
+        client.initialize(&admin);
+        (env, admin, donor, farmer, token_id, client)
+    }
+
+    fn proof(env: &Env, seed: u8) -> BytesN<32> {
+        BytesN::from_array(env, &[seed; 32])
+    }
+
+    #[test]
+    fn test_full_lifecycle() {
+        let (env, _admin, donor, farmer, token, client) = setup();
+
+        // Deposit
+        client.deposit(&donor, &farmer, &token, &10_000);
+        assert_eq!(client.get_record(&farmer).unwrap().status, EscrowStatus::Funded);
+
+        // Verify planting → 75% released
+        client.verify_planting(&farmer, &proof(&env, 1));
+        let rec = client.get_record(&farmer).unwrap();
+        assert_eq!(rec.released, 7_500);
+        assert_eq!(rec.status, EscrowStatus::Planted);
+
+        // Fast-forward ledger by 6 months
+        env.ledger().with_mut(|l| l.timestamp += SIX_MONTHS_SECS + 1);
+
+        // Verify survival → remaining 25% released
+        client.verify_survival(&farmer, &proof(&env, 2));
+        let rec = client.get_record(&farmer).unwrap();
+        assert_eq!(rec.released, 10_000);
+        assert_eq!(rec.status, EscrowStatus::Completed);
+    }
+
+    #[test]
+    #[should_panic(expected = "6-month survival period not yet elapsed")]
+    fn test_survival_too_early_rejected() {
+        let (env, _admin, donor, farmer, token, client) = setup();
+
+        client.deposit(&donor, &farmer, &token, &10_000);
+        client.verify_planting(&farmer, &proof(&env, 1));
+
+        // Only 1 day later — should panic
+        env.ledger().with_mut(|l| l.timestamp += 86_400);
+        client.verify_survival(&farmer, &proof(&env, 2));
+    }
+
+    #[test]
+    #[should_panic(expected = "planting already verified")]
+    fn test_double_planting_rejected() {
+        let (env, _admin, donor, farmer, token, client) = setup();
+
+        client.deposit(&donor, &farmer, &token, &10_000);
+        client.verify_planting(&farmer, &proof(&env, 1));
+        client.verify_planting(&farmer, &proof(&env, 1)); // must panic
+    }
+
+    #[test]
+    fn test_refund_before_planting() {
+        let (_env, _admin, donor, farmer, token, client) = setup();
+
+        client.deposit(&donor, &farmer, &token, &10_000);
+        client.refund(&farmer);
+        assert_eq!(client.get_record(&farmer).unwrap().status, EscrowStatus::Refunded);
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot refund after planting")]
+    fn test_refund_after_planting_rejected() {
+        let (env, _admin, donor, farmer, token, client) = setup();
+
+        client.deposit(&donor, &farmer, &token, &10_000);
+        client.verify_planting(&farmer, &proof(&env, 1));
+        client.refund(&farmer); // must panic
+    }
+}


### PR DESCRIPTION
Closes #310

## What

Core Soroban escrow contract that holds donor funds and releases them 
in two tranches tied to on-chain verified milestones.

## Release Schedule

| Tranche | Amount | Trigger |
|---------|--------|---------|
| 1 | 75% | GPS + photo proof of planting verified |
| 2 | 25% | 6-month survival verification (time-locked) |

## Functions

- deposit(donor, farmer, token, amount) — lock donor funds
- verify_planting(farmer, proof_hash) — release 75%, admin only
- verify_survival(farmer, proof_hash) — release 25% after 6 months, admin only
- refund(farmer) — return to donor if planting not yet verified
- get_record(farmer) — read current escrow state

## Time Lock

verify_survival() enforces that at least 6 months (26 weeks) have 
elapsed since planting was verified. Calling it early panics.

## Tests

- Full lifecycle (deposit → planting → survival → completed)
- Survival too early rejected
- Double planting verification rejected
- Refund before planting
- Refund after planting rejected
