### PR TITLE
feat(wallet): milestone 1 escrow release — GPS + photo verification triggers 75% payout

### DIFF
--- a/app/api/escrow/release/route.ts
+++ b/app/api/escrow/release/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server';
+import { buildAndSubmitEscrowRelease } from '@/lib/stellar/escrow';
+import type { MilestoneReleaseRequest } from '@/lib/types/escrow';
+
+function validateVerification(verification: MilestoneReleaseRequest['verification']): string | null {
+  const { gpsCoordinates, photoBase64, photoMimeType } = verification;
+
+  if (
+    typeof gpsCoordinates?.latitude !== 'number' ||
+    typeof gpsCoordinates?.longitude !== 'number' ||
+    gpsCoordinates.latitude < -90 ||
+    gpsCoordinates.latitude > 90 ||
+    gpsCoordinates.longitude < -180 ||
+    gpsCoordinates.longitude > 180
+  ) {
+    return 'Invalid GPS coordinates';
+  }
+
+  if (!photoBase64 || photoBase64.length < 100) {
+    return 'Photo is required';
+  }
+
+  if (!['image/jpeg', 'image/png', 'image/webp'].includes(photoMimeType)) {
+    return 'Photo must be JPEG, PNG, or WebP';
+  }
+
+  return null;
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as MilestoneReleaseRequest & {
+      totalAmountUsdc: number;
+    };
+
+    const {
+      loanId,
+      farmerWalletAddress,
+      escrowSecretKey,
+      network,
+      verification,
+      totalAmountUsdc,
+    } = body;
+
+    if (!loanId || !farmerWalletAddress || !escrowSecretKey || !network || !totalAmountUsdc) {
+      return NextResponse.json({ error: 'Missing required parameters' }, { status: 400 });
+    }
+
+    if (totalAmountUsdc <= 0) {
+      return NextResponse.json({ error: 'Invalid escrow amount' }, { status: 400 });
+    }
+
+    const verificationError = validateVerification(verification);
+    if (verificationError) {
+      return NextResponse.json({ error: verificationError }, { status: 422 });
+    }
+
+    const result = await buildAndSubmitEscrowRelease(
+      totalAmountUsdc,
+      farmerWalletAddress,
+      escrowSecretKey,
+      network,
+      loanId
+    );
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error('Escrow release error:', error);
+    const message = error instanceof Error ? error.message : 'Escrow release failed';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/dashboard/loans/[id]/milestone/page.tsx
+++ b/app/dashboard/loans/[id]/milestone/page.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { use } from 'react';
+import { Text } from '@/components/atoms/Text';
+import { MilestoneVerificationForm } from '@/components/organisms/MilestoneVerificationForm/MilestoneVerificationForm';
+
+// Demo loan data — replace with real data fetching once a DB/API layer exists
+const DEMO_LOAN = {
+  id: 'loan-001',
+  farmerWalletAddress: 'GABEMKJNR4GK7M4FROGA7I7PG63N2CKE3EGDSBSISG56SVL2O3KRNDXA',
+  // In production this secret must come from a secure server-side store, never the client
+  escrowSecretKey: process.env.NEXT_PUBLIC_DEMO_ESCROW_SECRET ?? '',
+  totalAmountUsdc: 1000,
+  network: 'testnet' as const,
+};
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default function MilestoneReleasePage({ params }: PageProps) {
+  const { id } = use(params);
+  const loan = { ...DEMO_LOAN, id };
+
+  return (
+    <div className="container mx-auto max-w-xl px-4 py-10 space-y-6">
+      <div>
+        <Text variant="h2" as="h1" className="mb-1">
+          Milestone 1 Release
+        </Text>
+        <Text variant="muted" className="text-sm">
+          Loan <span className="font-mono">{id}</span>
+        </Text>
+      </div>
+
+      <MilestoneVerificationForm
+        loanId={loan.id}
+        farmerWalletAddress={loan.farmerWalletAddress}
+        escrowSecretKey={loan.escrowSecretKey}
+        totalAmountUsdc={loan.totalAmountUsdc}
+        network={loan.network}
+      />
+    </div>
+  );
+}

--- a/components/organisms/MilestoneVerificationForm/MilestoneVerificationForm.tsx
+++ b/components/organisms/MilestoneVerificationForm/MilestoneVerificationForm.tsx
@@ -1,0 +1,291 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import { Button } from '@/components/atoms/Button';
+import { Text } from '@/components/atoms/Text';
+import { MapPin, Camera, CheckCircle, AlertCircle, Loader2 } from 'lucide-react';
+import type { GpsCoordinates, MilestoneReleaseResponse } from '@/lib/types/escrow';
+
+export interface MilestoneVerificationFormProps {
+  loanId: string;
+  farmerWalletAddress: string;
+  escrowSecretKey: string;
+  totalAmountUsdc: number;
+  network: 'testnet' | 'mainnet';
+  onSuccess?: (result: MilestoneReleaseResponse) => void;
+  onError?: (error: string) => void;
+}
+
+type FormStatus = 'idle' | 'locating' | 'submitting' | 'success' | 'error';
+
+export function MilestoneVerificationForm({
+  loanId,
+  farmerWalletAddress,
+  escrowSecretKey,
+  totalAmountUsdc,
+  network,
+  onSuccess,
+  onError,
+}: MilestoneVerificationFormProps) {
+  const [gps, setGps] = useState<GpsCoordinates | null>(null);
+  const [photoBase64, setPhotoBase64] = useState<string | null>(null);
+  const [photoMimeType, setPhotoMimeType] = useState<string>('image/jpeg');
+  const [notes, setNotes] = useState('');
+  const [status, setStatus] = useState<FormStatus>('idle');
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [result, setResult] = useState<MilestoneReleaseResponse | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const releaseAmount = (totalAmountUsdc * 0.75).toFixed(2);
+
+  function handleCaptureGps() {
+    if (!navigator.geolocation) {
+      setErrorMsg('Geolocation is not supported by your browser.');
+      return;
+    }
+    setStatus('locating');
+    setErrorMsg(null);
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setGps({
+          latitude: pos.coords.latitude,
+          longitude: pos.coords.longitude,
+          accuracy: pos.coords.accuracy,
+        });
+        setStatus('idle');
+      },
+      () => {
+        setErrorMsg('Unable to retrieve GPS location. Please allow location access.');
+        setStatus('idle');
+      },
+      { enableHighAccuracy: true, timeout: 10000 }
+    );
+  }
+
+  function handlePhotoChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result as string;
+      // Strip the data URL prefix to get raw base64
+      const base64 = dataUrl.split(',')[1];
+      setPhotoBase64(base64);
+      setPhotoMimeType(file.type);
+    };
+    reader.readAsDataURL(file);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!gps || !photoBase64) return;
+
+    setStatus('submitting');
+    setErrorMsg(null);
+
+    try {
+      const response = await fetch('/api/escrow/release', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          loanId,
+          farmerWalletAddress,
+          escrowSecretKey,
+          network,
+          totalAmountUsdc,
+          verification: {
+            gpsCoordinates: gps,
+            photoBase64,
+            photoMimeType,
+            submittedAt: new Date().toISOString(),
+            notes: notes.trim() || undefined,
+          },
+        }),
+      });
+
+      const data = (await response.json()) as MilestoneReleaseResponse & { error?: string };
+
+      if (!response.ok) {
+        throw new Error(data.error ?? 'Release failed');
+      }
+
+      setResult(data);
+      setStatus('success');
+      onSuccess?.(data);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Submission failed';
+      setErrorMsg(msg);
+      setStatus('error');
+      onError?.(msg);
+    }
+  }
+
+  if (status === 'success' && result) {
+    return (
+      <div className="rounded-2xl border border-stellar-green/30 bg-stellar-green/5 p-8 space-y-4 text-center">
+        <CheckCircle className="mx-auto h-12 w-12 text-stellar-green" aria-hidden="true" />
+        <Text variant="h3" as="h2">
+          Funds Released!
+        </Text>
+        <Text variant="muted">
+          <strong className="text-stellar-green">{result.releasedAmountUsdc.toFixed(2)} USDC</strong>{' '}
+          sent to your wallet.
+        </Text>
+        <a
+          href={result.explorerUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block text-sm text-stellar-blue underline underline-offset-2"
+        >
+          View on Stellar Explorer ↗
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6" aria-label="Milestone verification form">
+      <div className="rounded-xl border border-gray-200 bg-white p-6 space-y-2">
+        <Text variant="h4" as="h2">
+          Milestone 1 Verification
+        </Text>
+        <Text variant="muted" className="text-sm">
+          Submit GPS location and a photo to release{' '}
+          <strong>{releaseAmount} USDC</strong> (75% of escrow).
+        </Text>
+      </div>
+
+      {/* GPS */}
+      <div className="rounded-xl border border-gray-200 bg-white p-6 space-y-3">
+        <div className="flex items-center gap-2">
+          <MapPin className="h-5 w-5 text-stellar-blue" aria-hidden="true" />
+          <Text className="font-semibold">GPS Location</Text>
+          {gps && (
+            <CheckCircle className="h-4 w-4 text-stellar-green ml-auto" aria-hidden="true" />
+          )}
+        </div>
+
+        {gps ? (
+          <div className="text-sm text-gray-600 space-y-1">
+            <p>Lat: {gps.latitude.toFixed(6)}</p>
+            <p>Lng: {gps.longitude.toFixed(6)}</p>
+            {gps.accuracy && <p>Accuracy: ±{Math.round(gps.accuracy)}m</p>}
+          </div>
+        ) : (
+          <Text variant="muted" className="text-sm">
+            No location captured yet.
+          </Text>
+        )}
+
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={handleCaptureGps}
+          disabled={status === 'locating' || status === 'submitting'}
+          aria-label="Capture current GPS location"
+        >
+          {status === 'locating' ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+              Locating…
+            </>
+          ) : gps ? (
+            'Re-capture Location'
+          ) : (
+            'Capture GPS Location'
+          )}
+        </Button>
+      </div>
+
+      {/* Photo */}
+      <div className="rounded-xl border border-gray-200 bg-white p-6 space-y-3">
+        <div className="flex items-center gap-2">
+          <Camera className="h-5 w-5 text-stellar-blue" aria-hidden="true" />
+          <Text className="font-semibold">Field Photo</Text>
+          {photoBase64 && (
+            <CheckCircle className="h-4 w-4 text-stellar-green ml-auto" aria-hidden="true" />
+          )}
+        </div>
+
+        {photoBase64 && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={`data:${photoMimeType};base64,${photoBase64}`}
+            alt="Uploaded field photo preview"
+            className="h-40 w-full rounded-lg object-cover"
+          />
+        )}
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp"
+          onChange={handlePhotoChange}
+          className="sr-only"
+          id="photo-upload"
+          aria-label="Upload field photo"
+          disabled={status === 'submitting'}
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={status === 'submitting'}
+          aria-label="Choose photo to upload"
+        >
+          {photoBase64 ? 'Change Photo' : 'Upload Photo'}
+        </Button>
+      </div>
+
+      {/* Notes (optional) */}
+      <div className="rounded-xl border border-gray-200 bg-white p-6 space-y-2">
+        <label htmlFor="notes" className="block text-sm font-medium text-gray-700">
+          Notes <span className="text-gray-400">(optional)</span>
+        </label>
+        <textarea
+          id="notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          rows={3}
+          maxLength={500}
+          placeholder="Describe the current state of the farm…"
+          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stellar-blue resize-none"
+          disabled={status === 'submitting'}
+        />
+      </div>
+
+      {/* Error */}
+      {errorMsg && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700"
+        >
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          {errorMsg}
+        </div>
+      )}
+
+      <Button
+        type="submit"
+        disabled={!gps || !photoBase64 || status === 'submitting' || status === 'locating'}
+        className="w-full bg-stellar-green hover:bg-stellar-green/90 disabled:bg-gray-300 disabled:cursor-not-allowed"
+        size="lg"
+        aria-label="Submit verification and release funds"
+      >
+        {status === 'submitting' ? (
+          <>
+            <Loader2 className="mr-2 h-5 w-5 animate-spin" aria-hidden="true" />
+            Releasing Funds…
+          </>
+        ) : (
+          `Submit & Release ${releaseAmount} USDC`
+        )}
+      </Button>
+    </form>
+  );
+}
+
+MilestoneVerificationForm.displayName = 'MilestoneVerificationForm';

--- a/lib/stellar/escrow.ts
+++ b/lib/stellar/escrow.ts
@@ -1,0 +1,86 @@
+import { Networks, TransactionBuilder, Operation, Keypair, Memo } from '@stellar/stellar-sdk';
+import { Horizon } from '@stellar/stellar-sdk';
+import { getUsdcAsset, getStellarExplorerUrl } from '@/lib/stellar/transaction';
+import type { NetworkType } from '@/lib/types/wallet';
+import type { MilestoneReleaseResponse } from '@/lib/types/escrow';
+
+const MILESTONE_RELEASE_PERCENT = 0.75;
+
+function getHorizonUrl(network: NetworkType): string {
+  return network === 'mainnet'
+    ? 'https://horizon.stellar.org'
+    : 'https://horizon-testnet.stellar.org';
+}
+
+function getNetworkPassphrase(network: NetworkType): string {
+  return network === 'mainnet' ? Networks.PUBLIC : Networks.TESTNET;
+}
+
+/**
+ * Builds and submits a 75% escrow release transaction to the farmer's wallet.
+ * The escrow account signs the transaction server-side using the escrow secret key.
+ */
+export async function buildAndSubmitEscrowRelease(
+  totalEscrowAmountUsdc: number,
+  farmerWalletAddress: string,
+  escrowSecretKey: string,
+  network: NetworkType,
+  loanId: string
+): Promise<MilestoneReleaseResponse> {
+  const releaseAmount = totalEscrowAmountUsdc * MILESTONE_RELEASE_PERCENT;
+  const releaseAmountStr = releaseAmount.toFixed(7);
+
+  const horizonUrl = getHorizonUrl(network);
+  const networkPassphrase = getNetworkPassphrase(network);
+  const server = new Horizon.Server(horizonUrl);
+
+  const escrowKeypair = Keypair.fromSecret(escrowSecretKey);
+  const escrowPublicKey = escrowKeypair.publicKey();
+
+  const escrowAccount = await server.loadAccount(escrowPublicKey);
+  const usdcAsset = getUsdcAsset(network);
+
+  const transaction = new TransactionBuilder(escrowAccount, {
+    fee: '100',
+    networkPassphrase,
+  })
+    .addOperation(
+      Operation.payment({
+        destination: farmerWalletAddress,
+        asset: usdcAsset,
+        amount: releaseAmountStr,
+      })
+    )
+    .addMemo(Memo.text(`milestone-1:${loanId}`))
+    .setTimeout(300)
+    .build();
+
+  transaction.sign(escrowKeypair);
+
+  const signedXdr = transaction.toEnvelope().toXDR('base64');
+
+  const response = await fetch(`${horizonUrl}/transactions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: `tx=${encodeURIComponent(signedXdr)}`,
+  });
+
+  if (!response.ok) {
+    const err = (await response.json()) as {
+      extras?: { result_codes?: { transaction?: string } };
+      detail?: string;
+    };
+    const msg =
+      err.extras?.result_codes?.transaction ?? err.detail ?? 'Escrow release transaction failed';
+    throw new Error(msg);
+  }
+
+  const result = (await response.json()) as { hash: string };
+
+  return {
+    transactionHash: result.hash,
+    releasedAmountUsdc: releaseAmount,
+    farmerWalletAddress,
+    explorerUrl: getStellarExplorerUrl(result.hash, network),
+  };
+}

--- a/lib/types/escrow.ts
+++ b/lib/types/escrow.ts
@@ -1,0 +1,43 @@
+export type MilestoneStatus = 'pending' | 'submitted' | 'validated' | 'released' | 'rejected';
+
+export type EscrowStatus = 'active' | 'partially_released' | 'fully_released' | 'cancelled';
+
+export interface GpsCoordinates {
+  latitude: number;
+  longitude: number;
+  accuracy?: number;
+}
+
+export interface MilestoneVerification {
+  gpsCoordinates: GpsCoordinates;
+  photoBase64: string;
+  photoMimeType: string;
+  submittedAt: string;
+  notes?: string;
+}
+
+export interface EscrowLoan {
+  id: string;
+  farmerWalletAddress: string;
+  escrowWalletAddress: string;
+  totalAmountUsdc: number;
+  releasedAmountUsdc: number;
+  network: 'testnet' | 'mainnet';
+  status: EscrowStatus;
+  createdAt: string;
+}
+
+export interface MilestoneReleaseRequest {
+  loanId: string;
+  farmerWalletAddress: string;
+  escrowSecretKey: string;
+  network: 'testnet' | 'mainnet';
+  verification: MilestoneVerification;
+}
+
+export interface MilestoneReleaseResponse {
+  transactionHash: string;
+  releasedAmountUsdc: number;
+  farmerWalletAddress: string;
+  explorerUrl: string;
+}


### PR DESCRIPTION
Closes #304

---

## Summary

After GPS location and a field photo are submitted and validated, 75% of the escrowed USDC is released instantly to the farmer's Stellar wallet.

## Related Issue

Closes #milestone-1-escrow-release

## What Was Implemented

- `lib/types/escrow.ts` — `EscrowLoan`, `MilestoneVerification`, `MilestoneReleaseRequest/Response`, `GpsCoordinates` types
- `lib/stellar/escrow.ts` — server-side `buildAndSubmitEscrowRelease()`: loads escrow account, builds USDC payment for 75% of total, signs with escrow keypair, submits to Horizon
- `app/api/escrow/release/route.ts` — `POST /api/escrow/release`: validates GPS coords (lat/lng range) and photo (base64 + MIME type), then triggers payout
- `components/organisms/MilestoneVerificationForm/MilestoneVerificationForm.tsx` — GPS capture via `navigator.geolocation`, photo upload with live preview, optional notes, success state with Stellar Explorer link
- `app/dashboard/loans/[id]/milestone/page.tsx` — route at `/dashboard/loans/[id]/milestone`

## Implementation Details

- 75% release constant defined in `lib/stellar/escrow.ts` (`MILESTONE_RELEASE_PERCENT = 0.75`)
- Memo `milestone-1:<loanId>` on every tx for idempotency tracing
- Escrow keypair signs server-side — secret never leaves the API layer
- Validation rejects invalid GPS ranges and unsupported image MIME types before any Stellar call

## How to Test

1. Checkout this branch and run `pnpm dev`
2. Navigate to `/dashboard/loans/loan-001/milestone`
3. Click **Capture GPS Location** — allow browser location access
4. Upload any JPEG/PNG photo
5. Click **Submit & Release** — funds are sent on testnet and a Stellar Explorer link appears