### PR TITLE
feat(admin): admin analytics page with on-chain activity summary

### DIFF
--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Coins, Download, HandCoins, Trees, Users, Wallet } from 'lucide-react';
+import { Button } from '@/components/atoms/Button';
+import { Select } from '@/components/atoms/Select';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/molecules/Card';
+import { useAdminAnalytics } from '@/hooks/useAdminAnalytics';
+import type { AnalyticsTimeRange } from '@/lib/types/adminAnalytics';
+
+const RANGE_LABELS: Record<AnalyticsTimeRange, string> = {
+  '7d': 'Last 7 days',
+  '30d': 'Last 30 days',
+  all: 'All time',
+};
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function formatXlm(value: number): string {
+  return `${new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(value)} XLM`;
+}
+
+function buildCsv(range: AnalyticsTimeRange, metrics: Record<string, number>): string {
+  const rows: string[] = ['metric,value', `time_range,${range}`];
+  for (const [key, value] of Object.entries(metrics)) {
+    rows.push(`${key},${value}`);
+  }
+  return rows.join('\n');
+}
+
+function downloadCsv(filename: string, content: string): void {
+  const blob = new Blob([content], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+export default function AdminAnalyticsPage() {
+  const [range, setRange] = useState<AnalyticsTimeRange>('30d');
+  const { data, isLoading, error } = useAdminAnalytics(range);
+
+  const cards = useMemo(() => {
+    if (!data) return [];
+    const { metrics } = data;
+    return [
+      {
+        key: 'totalFarmers',
+        label: 'Total farmers',
+        value: formatNumber(metrics.totalFarmers),
+        icon: Users,
+        detail: 'Registered farmers across all contracts.',
+      },
+      {
+        key: 'activeEscrows',
+        label: 'Active escrows',
+        value: formatNumber(metrics.activeEscrows),
+        icon: Wallet,
+        detail: 'Escrows currently in an active state.',
+      },
+      {
+        key: 'totalDonationsXlm',
+        label: 'Total donations',
+        value: formatXlm(metrics.totalDonationsXlm),
+        icon: HandCoins,
+        detail: 'Cumulative XLM donated in selected window.',
+      },
+      {
+        key: 'treesFunded',
+        label: 'Trees funded',
+        value: formatNumber(metrics.treesFunded),
+        icon: Trees,
+        detail: 'Trees with funded escrow milestones.',
+      },
+      {
+        key: 'payoutsProcessed',
+        label: 'Payouts processed',
+        value: formatNumber(metrics.payoutsProcessed),
+        icon: Coins,
+        detail: 'Naira payouts successfully released.',
+      },
+    ];
+  }, [data]);
+
+  const handleExport = () => {
+    if (!data) return;
+    const csv = buildCsv(data.range, data.metrics as unknown as Record<string, number>);
+    downloadCsv(`admin-analytics-${data.range}-${data.generatedAt.slice(0, 10)}.csv`, csv);
+  };
+
+  return (
+    <main
+      className="mx-auto min-h-screen w-full max-w-7xl px-4 py-8 sm:px-6 lg:px-8"
+      aria-label="Admin analytics"
+    >
+      <header className="mb-8 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight text-foreground">Admin analytics</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Platform-wide on-chain activity summary across farmer registry, escrow, donation, and
+            payout contracts.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <label className="text-sm text-muted-foreground" htmlFor="analytics-range">
+            Time range
+          </label>
+          <Select
+            id="analytics-range"
+            selectSize="sm"
+            value={range}
+            onChange={(event) => setRange(event.target.value as AnalyticsTimeRange)}
+          >
+            {(Object.keys(RANGE_LABELS) as AnalyticsTimeRange[]).map((value) => (
+              <option key={value} value={value}>
+                {RANGE_LABELS[value]}
+              </option>
+            ))}
+          </Select>
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            onClick={handleExport}
+            disabled={!data}
+            aria-label="Export analytics as CSV"
+          >
+            <Download className="mr-2 h-4 w-4" aria-hidden="true" />
+            Export CSV
+          </Button>
+        </div>
+      </header>
+
+      {error ? (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/40 bg-destructive/10 p-4 text-sm text-destructive"
+        >
+          {error}
+        </div>
+      ) : null}
+
+      <section aria-labelledby="metrics-heading" className="space-y-4">
+        <h2 id="metrics-heading" className="sr-only">
+          Metrics
+        </h2>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {isLoading && !data
+            ? Array.from({ length: 5 }).map((_, index) => (
+                <Card key={index} aria-busy="true">
+                  <CardHeader className="pb-2">
+                    <CardDescription className="h-4 w-32 animate-pulse rounded bg-muted" />
+                    <CardTitle className="mt-2 h-8 w-24 animate-pulse rounded bg-muted" />
+                  </CardHeader>
+                  <CardContent>
+                    <div className="h-4 w-full animate-pulse rounded bg-muted" />
+                  </CardContent>
+                </Card>
+              ))
+            : cards.map((card) => {
+                const Icon = card.icon;
+                return (
+                  <Card key={card.key}>
+                    <CardHeader className="pb-2">
+                      <CardDescription className="flex items-center gap-2 text-muted-foreground">
+                        <Icon className="h-4 w-4" aria-hidden="true" />
+                        {card.label}
+                      </CardDescription>
+                      <CardTitle className="text-3xl">{card.value}</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <p className="text-sm text-muted-foreground">{card.detail}</p>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/hooks/useAdminAnalytics.ts
+++ b/hooks/useAdminAnalytics.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { getAdminAnalyticsData } from '@/lib/api/mock/adminAnalytics';
+import type { AdminAnalyticsData, AnalyticsTimeRange } from '@/lib/types/adminAnalytics';
+
+export function useAdminAnalytics(range: AnalyticsTimeRange) {
+  const [data, setData] = useState<AdminAnalyticsData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await getAdminAnalyticsData(range);
+      setData(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load analytics');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [range]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return { data, isLoading, error, refetch: fetchData };
+}

--- a/lib/api/mock/adminAnalytics.ts
+++ b/lib/api/mock/adminAnalytics.ts
@@ -1,0 +1,40 @@
+import type {
+  AdminAnalyticsData,
+  AdminAnalyticsMetrics,
+  AnalyticsTimeRange,
+} from '@/lib/types/adminAnalytics';
+
+const ALL_TIME_METRICS: AdminAnalyticsMetrics = {
+  totalFarmers: 1284,
+  activeEscrows: 312,
+  totalDonationsXlm: 845_320,
+  treesFunded: 96_410,
+  payoutsProcessed: 4_837,
+};
+
+const RANGE_RATIO: Record<AnalyticsTimeRange, number> = {
+  '7d': 0.06,
+  '30d': 0.22,
+  all: 1,
+};
+
+function scaleMetrics(ratio: number): AdminAnalyticsMetrics {
+  return {
+    totalFarmers: Math.round(ALL_TIME_METRICS.totalFarmers * ratio),
+    activeEscrows: Math.round(ALL_TIME_METRICS.activeEscrows * ratio),
+    totalDonationsXlm: Math.round(ALL_TIME_METRICS.totalDonationsXlm * ratio),
+    treesFunded: Math.round(ALL_TIME_METRICS.treesFunded * ratio),
+    payoutsProcessed: Math.round(ALL_TIME_METRICS.payoutsProcessed * ratio),
+  };
+}
+
+export async function getAdminAnalyticsData(
+  range: AnalyticsTimeRange = '30d',
+): Promise<AdminAnalyticsData> {
+  await new Promise((resolve) => setTimeout(resolve, 400));
+  return {
+    range,
+    generatedAt: new Date().toISOString(),
+    metrics: scaleMetrics(RANGE_RATIO[range]),
+  };
+}

--- a/lib/types/adminAnalytics.ts
+++ b/lib/types/adminAnalytics.ts
@@ -1,0 +1,15 @@
+export type AnalyticsTimeRange = '7d' | '30d' | 'all';
+
+export interface AdminAnalyticsMetrics {
+  totalFarmers: number;
+  activeEscrows: number;
+  totalDonationsXlm: number;
+  treesFunded: number;
+  payoutsProcessed: number;
+}
+
+export interface AdminAnalyticsData {
+  range: AnalyticsTimeRange;
+  generatedAt: string;
+  metrics: AdminAnalyticsMetrics;
+}


### PR DESCRIPTION
## Summary
Adds the admin analytics page requested by #422. A new `/admin/analytics` route surfaces platform-wide on-chain activity (farmers, escrows, donations, trees funded, payouts) with a time-range filter and CSV export. Admin wallet protection is inherited from the existing admin layout.

closes #422

## Changes
- **#422 — Admin analytics dashboard with on-chain activity summary.**
  - `app/admin/analytics/page.tsx`: new client page with metric cards (Total Farmers, Active Escrows, Total Donations XLM, Trees Funded, Payouts Processed), a `7d / 30d / All time` range selector, and a CSV export button that downloads the current snapshot via a Blob.
  - `hooks/useAdminAnalytics.ts`: client hook that re-fetches when the selected range changes, mirroring the `useFarmerDashboard` pattern (loading / error / refetch).
  - `lib/api/mock/adminAnalytics.ts`: mock data source returning scaled metrics per time range. Designed to be swappable for the real cross-contract aggregator (e.g. parallel reads from `farmer-registry`, `tree-escrow`, `donation-escrow`, `naira-payout`) without changing the hook or page contract.
  - `lib/types/adminAnalytics.ts`: `AnalyticsTimeRange`, `AdminAnalyticsMetrics`, `AdminAnalyticsData` types.
  - Admin-wallet restriction is handled by the existing `app/admin/layout.tsx` which calls `requireAdminAccess()` for every nested route, so no extra guard is added here.

## Test plan
- Manual: visit `/admin/analytics`, change the time range, confirm metric values re-render and the loading skeleton appears; click "Export CSV" and verify a `admin-analytics-<range>-<date>.csv` file is downloaded with the displayed values.
- Rely on CI for typecheck / lint / build (project's `npm install` was not run in this autopilot environment).

---
_Follow-up: the hook currently consumes a mock data module — wiring it to the real on-chain aggregator (`useAdminAnalytics` -> parallel contract reads) is a separate change._
