### PR TITLE
refactor(ui)+feat(layout): UI primitives polish and root layout SEO/a11y baseline

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -226,6 +226,15 @@
 
 /* Respect prefers-reduced-motion */
 @media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+
   .skeleton-shimmer {
     animation: none;
     background: var(--muted);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,14 +8,35 @@ import { WalletProviderWrapper } from '@/components/providers/WalletProviderWrap
 import { FavoritesProvider } from '@/contexts/FavouritesContext';
 import './globals.css';
 
+const siteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL ?? 'https://farmcredit.app';
+const siteName = 'FarmCredit';
+const siteDescription = 'FarmCredit - Decentralized agricultural credit on Stellar';
+const ogImage = '/icons/icon-512x512.png';
+
 export const metadata: Metadata = {
-  title: 'FarmCredit',
-  description: 'FarmCredit - Decentralized agricultural credit on Stellar',
+  metadataBase: new URL(siteUrl),
+  title: {
+    default: siteName,
+    template: `%s | ${siteName}`,
+  },
+  description: siteDescription,
+  applicationName: siteName,
+  keywords: [
+    'Stellar',
+    'FarmCredit',
+    'agriculture',
+    'decentralized finance',
+    'DeFi',
+    'credit',
+    'farming',
+    'blockchain',
+  ],
   manifest: '/manifest.json',
   appleWebApp: {
     capable: true,
     statusBarStyle: 'default',
-    title: 'FarmCredit',
+    title: siteName,
   },
   formatDetection: {
     telephone: false,
@@ -29,6 +50,33 @@ export const metadata: Metadata = {
       { url: '/icons/icon-152x152.png', sizes: '152x152', type: 'image/png' },
       { url: '/icons/icon-192x192.png', sizes: '192x192', type: 'image/png' },
     ],
+    shortcut: '/icon-source.svg',
+  },
+  openGraph: {
+    type: 'website',
+    siteName,
+    title: siteName,
+    description: siteDescription,
+    url: siteUrl,
+    locale: 'en_US',
+    images: [
+      {
+        url: ogImage,
+        width: 512,
+        height: 512,
+        alt: `${siteName} - Decentralized agricultural credit on Stellar`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: siteName,
+    description: siteDescription,
+    images: [ogImage],
+  },
+  robots: {
+    index: true,
+    follow: true,
   },
 };
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -121,13 +121,21 @@ export default function RootLayout({
             })();
           `}
         </Script>
+        <a
+          href="#main"
+          className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground focus:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          Skip to content
+        </a>
         <QueryProvider>
           <WalletProviderWrapper>
             <FavoritesProvider>
               <ToastProvider>
                 <CookieBanner />
                 <Header />
-                {children}
+                <main id="main" tabIndex={-1}>
+                  {children}
+                </main>
                 <Footer />
               </ToastProvider>
             </FavoritesProvider>

--- a/components/atoms/Badge.tsx
+++ b/components/atoms/Badge.tsx
@@ -26,6 +26,7 @@ type BadgeProps = HTMLAttributes<HTMLDivElement> & VariantProps<typeof badgeVari
 function Badge({ className, variant, ...props }: BadgeProps) {
   return <div className={cn(badgeVariants({ variant, className }))} {...props} />;
 }
+Badge.displayName = 'Badge';
 
 export { Badge, badgeVariants };
 export type { BadgeProps };

--- a/components/atoms/Badge.tsx
+++ b/components/atoms/Badge.tsx
@@ -1,4 +1,4 @@
-import { type HTMLAttributes } from 'react';
+import { forwardRef, type HTMLAttributes } from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
@@ -23,9 +23,9 @@ const badgeVariants = cva(
 
 type BadgeProps = HTMLAttributes<HTMLDivElement> & VariantProps<typeof badgeVariants>;
 
-function Badge({ className, variant, ...props }: BadgeProps) {
-  return <div className={cn(badgeVariants({ variant, className }))} {...props} />;
-}
+const Badge = forwardRef<HTMLDivElement, BadgeProps>(({ className, variant, ...props }, ref) => {
+  return <div ref={ref} className={cn(badgeVariants({ variant, className }))} {...props} />;
+});
 Badge.displayName = 'Badge';
 
 export { Badge, badgeVariants };

--- a/components/atoms/Badge.tsx
+++ b/components/atoms/Badge.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring',
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
   {
     variants: {
       variant: {

--- a/components/atoms/Text.tsx
+++ b/components/atoms/Text.tsx
@@ -39,6 +39,7 @@ function Text({ className, variant, as, ...props }: TextProps) {
 
   return <Component className={cn(textVariants({ variant, className }))} {...props} />;
 }
+Text.displayName = 'Text';
 
 export { Text, textVariants };
 export type { TextProps };

--- a/components/atoms/Text.tsx
+++ b/components/atoms/Text.tsx
@@ -1,4 +1,4 @@
-import { type HTMLAttributes } from 'react';
+import { forwardRef, type HTMLAttributes } from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
@@ -24,7 +24,7 @@ type TextProps = HTMLAttributes<HTMLElement> &
     as?: 'h1' | 'h2' | 'h3' | 'h4' | 'p' | 'span';
   };
 
-function Text({ className, variant, as, ...props }: TextProps) {
+const Text = forwardRef<HTMLElement, TextProps>(({ className, variant, as, ...props }, ref) => {
   const elementMap = {
     h1: 'h1',
     h2: 'h2',
@@ -35,10 +35,16 @@ function Text({ className, variant, as, ...props }: TextProps) {
     muted: 'p',
   } as const;
 
-  const Component = as || elementMap[variant || 'body'] || 'p';
+  const Component = (as || elementMap[variant || 'body'] || 'p') as 'p';
 
-  return <Component className={cn(textVariants({ variant, className }))} {...props} />;
-}
+  return (
+    <Component
+      ref={ref as React.Ref<HTMLParagraphElement>}
+      className={cn(textVariants({ variant, className }))}
+      {...props}
+    />
+  );
+});
 Text.displayName = 'Text';
 
 export { Text, textVariants };

--- a/components/molecules/Card.tsx
+++ b/components/molecules/Card.tsx
@@ -9,10 +9,12 @@ function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
     />
   );
 }
+Card.displayName = 'Card';
 
 function CardHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
   return <div className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />;
 }
+CardHeader.displayName = 'CardHeader';
 
 function CardTitle({ className, ...props }: HTMLAttributes<HTMLHeadingElement>) {
   return (
@@ -22,17 +24,21 @@ function CardTitle({ className, ...props }: HTMLAttributes<HTMLHeadingElement>) 
     />
   );
 }
+CardTitle.displayName = 'CardTitle';
 
 function CardDescription({ className, ...props }: HTMLAttributes<HTMLParagraphElement>) {
   return <p className={cn('text-sm text-muted-foreground', className)} {...props} />;
 }
+CardDescription.displayName = 'CardDescription';
 
 function CardContent({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
   return <div className={cn('p-6 pt-0', className)} {...props} />;
 }
+CardContent.displayName = 'CardContent';
 
 function CardFooter({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
   return <div className={cn('flex items-center p-6 pt-0', className)} {...props} />;
 }
+CardFooter.displayName = 'CardFooter';
 
 export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter };

--- a/components/molecules/Card.tsx
+++ b/components/molecules/Card.tsx
@@ -1,44 +1,67 @@
-import { type HTMLAttributes } from 'react';
+import { forwardRef, type HTMLAttributes } from 'react';
 import { cn } from '@/lib/utils';
 
-function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+type CardProps = HTMLAttributes<HTMLDivElement>;
+type CardHeaderProps = HTMLAttributes<HTMLDivElement>;
+type CardTitleProps = HTMLAttributes<HTMLHeadingElement>;
+type CardDescriptionProps = HTMLAttributes<HTMLParagraphElement>;
+type CardContentProps = HTMLAttributes<HTMLDivElement>;
+type CardFooterProps = HTMLAttributes<HTMLDivElement>;
+
+const Card = forwardRef<HTMLDivElement, CardProps>(({ className, ...props }, ref) => {
   return (
     <div
+      ref={ref}
       className={cn('rounded-xl border bg-card text-card-foreground shadow-sm', className)}
       {...props}
     />
   );
-}
+});
 Card.displayName = 'Card';
 
-function CardHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />;
-}
+const CardHeader = forwardRef<HTMLDivElement, CardHeaderProps>(({ className, ...props }, ref) => {
+  return (
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+  );
+});
 CardHeader.displayName = 'CardHeader';
 
-function CardTitle({ className, ...props }: HTMLAttributes<HTMLHeadingElement>) {
+const CardTitle = forwardRef<HTMLHeadingElement, CardTitleProps>(({ className, ...props }, ref) => {
   return (
     <h3
+      ref={ref}
       className={cn('text-2xl font-semibold leading-none tracking-tight', className)}
       {...props}
     />
   );
-}
+});
 CardTitle.displayName = 'CardTitle';
 
-function CardDescription({ className, ...props }: HTMLAttributes<HTMLParagraphElement>) {
-  return <p className={cn('text-sm text-muted-foreground', className)} {...props} />;
-}
+const CardDescription = forwardRef<HTMLParagraphElement, CardDescriptionProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <p ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+    );
+  }
+);
 CardDescription.displayName = 'CardDescription';
 
-function CardContent({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn('p-6 pt-0', className)} {...props} />;
-}
+const CardContent = forwardRef<HTMLDivElement, CardContentProps>(({ className, ...props }, ref) => {
+  return <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />;
+});
 CardContent.displayName = 'CardContent';
 
-function CardFooter({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn('flex items-center p-6 pt-0', className)} {...props} />;
-}
+const CardFooter = forwardRef<HTMLDivElement, CardFooterProps>(({ className, ...props }, ref) => {
+  return <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />;
+});
 CardFooter.displayName = 'CardFooter';
 
 export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter };
+export type {
+  CardProps,
+  CardHeaderProps,
+  CardTitleProps,
+  CardDescriptionProps,
+  CardContentProps,
+  CardFooterProps,
+};


### PR DESCRIPTION
## Summary

Batches four small, related polish PRs targeting the design-system primitives (`Badge`, `Text`, `Card*`) and the root `app/layout.tsx`:

- **#450** Adds the required `displayName` to `Badge`, `Text`, and every `Card` subcomponent so React DevTools shows real names (matches the existing `Button` / `Input` pattern).
- **#451** Converts `Card` (and subcomponents), `Badge`, and `Text` to `forwardRef`, and exports `CardProps` / `CardHeaderProps` / `CardTitleProps` / `CardDescriptionProps` / `CardContentProps` / `CardFooterProps`. `BadgeProps` and `TextProps` were already exported; refs now reach the underlying DOM nodes. No visual or API regressions.
- **#452** Adds `metadataBase`, `openGraph`, `twitter`, `keywords`, `robots`, and a templated title to the root metadata. Uses `NEXT_PUBLIC_SITE_URL` with a sensible default so there is no more "metadataBase not set" build warning. OG/Twitter images reuse the existing `/icons/icon-512x512.png` so no new binary assets are introduced; teams can swap this for a dedicated 1200×630 OG image later without touching code.
- **#453** Adds a keyboard-only "Skip to content" link, wraps `{children}` in `<main id="main" tabIndex={-1}>`, switches `Badge` focus styles from `focus:` to `focus-visible:` to align with `Button` / `Input`, and adds a global `prefers-reduced-motion: reduce` rule in `globals.css` that neutralises animations / transitions for users who request reduced motion (the existing `.skeleton-shimmer` carve-out is preserved).

closes #450
closes #451
closes #452
closes #453

## Files changed

- `components/atoms/Badge.tsx` — `forwardRef`, `displayName`, `focus-visible:` styles.
- `components/atoms/Text.tsx` — `forwardRef`, `displayName`.
- `components/molecules/Card.tsx` — all six subcomponents to `forwardRef`, `displayName` on each, exported per-component prop types.
- `app/layout.tsx` — expanded `metadata` (`metadataBase`, `openGraph`, `twitter`, `keywords`, `robots`), skip-link, `<main id="main">` landmark.
- `app/globals.css` — global `prefers-reduced-motion: reduce` baseline (kept the existing skeleton override).

## Test plan

- [ ] CI: lint, type-check, build.
- [ ] DevTools: `Badge`, `Text`, `Card*` show real component names (not `Anonymous`).
- [ ] Pass a `ref` to `Badge` / `Text` / each `Card*` and confirm it lands on the DOM node.
- [ ] `import type { CardProps, BadgeProps, TextProps } from '...'` compiles.
- [ ] Tab from the address bar: first focus shows the "Skip to content" link, Enter jumps to `<main>`.
- [ ] OS-level "Reduce motion" enabled → no skeleton shimmer, transitions effectively instant.
- [ ] Build no longer emits the `metadataBase` warning; social link previews resolve absolute URLs.

## Notes

- Could not run `pnpm install` / `pnpm lint` / `pnpm build` locally (sandbox blocks network + heavy installs). Changes were written to match the existing `Button.tsx` / `Input.tsx` patterns and to preserve every public API (`Badge` / `Text` / `Card*` still accept the same props and render the same DOM). CI is the source of truth.
- No new binary assets shipped; OG image points at the existing 512×512 PWA icon so the build does not break. Replacing with a purpose-built 1200×630 image is a content-only follow-up.