### PR TITLE
Add Textarea and Spinner components for UI

### DIFF
--- a/components/atoms/Alert.tsx
+++ b/components/atoms/Alert.tsx
@@ -1,0 +1,62 @@
+import { forwardRef, type HTMLAttributes } from 'react';
+import type { LucideIcon } from 'lucide-react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const alertVariants = cva('rounded-lg border px-4 py-3 text-sm', {
+  variants: {
+    variant: {
+      info: 'border-stellar-blue/30 bg-stellar-blue/10 text-stellar-blue',
+      success: 'border-stellar-green/30 bg-stellar-green/10 text-stellar-green',
+      warning: 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400',
+      destructive: 'border-destructive/40 bg-destructive/10 text-destructive',
+    },
+  },
+  defaultVariants: {
+    variant: 'info',
+  },
+});
+
+type AlertProps = HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof alertVariants> & {
+    icon?: LucideIcon;
+    role?: 'alert' | 'status';
+  };
+
+const Alert = forwardRef<HTMLDivElement, AlertProps>(
+  ({ className, variant, icon: Icon, role, children, ...props }, ref) => {
+    const resolvedRole =
+      role ?? (variant === 'warning' || variant === 'destructive' ? 'alert' : 'status');
+
+    return (
+      <div
+        ref={ref}
+        role={resolvedRole}
+        aria-live={resolvedRole === 'alert' ? 'assertive' : 'polite'}
+        className={cn('flex items-start gap-3', alertVariants({ variant }), className)}
+        {...props}
+      >
+        {Icon ? <Icon className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" /> : null}
+        <div className="min-w-0 flex-1 space-y-1">{children}</div>
+      </div>
+    );
+  }
+);
+Alert.displayName = 'Alert';
+
+const AlertTitle = forwardRef<HTMLParagraphElement, HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => {
+    return <p ref={ref} className={cn('font-medium leading-tight', className)} {...props} />;
+  }
+);
+AlertTitle.displayName = 'AlertTitle';
+
+const AlertDescription = forwardRef<HTMLParagraphElement, HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => {
+    return <p ref={ref} className={cn('text-sm opacity-90', className)} {...props} />;
+  }
+);
+AlertDescription.displayName = 'AlertDescription';
+
+export { Alert, AlertTitle, AlertDescription, alertVariants };
+export type { AlertProps };

--- a/components/atoms/Spinner.tsx
+++ b/components/atoms/Spinner.tsx
@@ -1,0 +1,54 @@
+import { forwardRef, type HTMLAttributes } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const spinnerVariants = cva(
+  'inline-block animate-spin motion-reduce:animate-none rounded-full border-2 border-current border-r-transparent',
+  {
+    variants: {
+      size: {
+        sm: 'h-4 w-4',
+        md: 'h-6 w-6',
+        lg: 'h-8 w-8',
+      },
+      variant: {
+        primary: 'text-stellar-blue',
+        accent: 'text-stellar-purple',
+        success: 'text-stellar-green',
+        destructive: 'text-destructive',
+        muted: 'text-muted-foreground',
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+      variant: 'primary',
+    },
+  }
+);
+
+type SpinnerProps = HTMLAttributes<HTMLSpanElement> &
+  VariantProps<typeof spinnerVariants> & {
+    srText?: string;
+  };
+
+const Spinner = forwardRef<HTMLSpanElement, SpinnerProps>(
+  ({ className, size, variant, srText = 'Loading', ...props }, ref) => {
+    return (
+      <span
+        ref={ref}
+        role="status"
+        aria-live="polite"
+        className={cn('inline-flex items-center justify-center', className)}
+        {...props}
+      >
+        <span aria-hidden="true" className={spinnerVariants({ size, variant })} />
+        <span className="sr-only">{srText}</span>
+      </span>
+    );
+  }
+);
+
+Spinner.displayName = 'Spinner';
+
+export { Spinner, spinnerVariants };
+export type { SpinnerProps };

--- a/components/atoms/Textarea.tsx
+++ b/components/atoms/Textarea.tsx
@@ -1,0 +1,71 @@
+import { forwardRef, type TextareaHTMLAttributes } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const textareaVariants = cva(
+  'flex w-full rounded-lg border bg-background px-3 py-2 text-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default: 'border-input focus-visible:ring-ring',
+        primary:
+          'border-stellar-blue/30 focus-visible:ring-stellar-blue focus-visible:border-stellar-blue',
+        accent:
+          'border-stellar-purple/30 focus-visible:ring-stellar-purple focus-visible:border-stellar-purple',
+        success:
+          'border-stellar-green/30 focus-visible:ring-stellar-green focus-visible:border-stellar-green',
+        destructive:
+          'border-destructive/50 focus-visible:ring-destructive focus-visible:border-destructive text-destructive',
+        ghost: 'border-transparent bg-muted focus-visible:ring-ring',
+      },
+      inputSize: {
+        sm: 'min-h-20 px-2.5 py-1.5 text-xs',
+        md: 'min-h-24 px-3 py-2 text-sm',
+        lg: 'min-h-32 px-4 py-3 text-base',
+      },
+      resize: {
+        none: 'resize-none',
+        vertical: 'resize-y',
+        horizontal: 'resize-x',
+        both: 'resize',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      inputSize: 'md',
+      resize: 'vertical',
+    },
+  }
+);
+
+type TextareaProps = Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'size'> &
+  VariantProps<typeof textareaVariants> & {
+    error?: boolean;
+  };
+
+const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  (
+    { className, variant, inputSize, resize, error, 'aria-invalid': ariaInvalid, ...props },
+    ref
+  ) => {
+    const hasError = Boolean(error || ariaInvalid === true || ariaInvalid === 'true');
+
+    return (
+      <textarea
+        className={cn(
+          textareaVariants({ variant, inputSize, resize, className }),
+          hasError &&
+            'border-destructive/50 text-destructive focus-visible:border-destructive focus-visible:ring-destructive'
+        )}
+        aria-invalid={hasError || ariaInvalid}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+
+Textarea.displayName = 'Textarea';
+
+export { Textarea, textareaVariants };
+export type { TextareaProps };

--- a/components/atoms/Textarea.tsx
+++ b/components/atoms/Textarea.tsx
@@ -55,9 +55,10 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         className={cn(
           textareaVariants({ variant, inputSize, resize, className }),
           hasError &&
+            variant !== 'destructive' &&
             'border-destructive/50 text-destructive focus-visible:border-destructive focus-visible:ring-destructive'
         )}
-        aria-invalid={hasError || ariaInvalid}
+        aria-invalid={hasError ? true : ariaInvalid}
         ref={ref}
         {...props}
       />

--- a/components/molecules/FormField.tsx
+++ b/components/molecules/FormField.tsx
@@ -56,7 +56,7 @@ const FormField = forwardRef<HTMLInputElement, FormFieldProps>(
           id={inputId}
           variant={hasError ? 'destructive' : variant}
           className={className}
-          aria-invalid={hasError || ariaInvalid}
+          aria-invalid={hasError ? true : ariaInvalid}
           aria-describedby={describedBy}
           {...inputProps}
         />

--- a/components/molecules/FormField.tsx
+++ b/components/molecules/FormField.tsx
@@ -1,0 +1,83 @@
+import { forwardRef, useId, type ComponentProps, type ReactNode } from 'react';
+import { Input, type InputProps } from '@/components/atoms/Input';
+import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
+
+type FormFieldProps = Omit<InputProps, 'id'> & {
+  id?: string;
+  label: ReactNode;
+  helperText?: ReactNode;
+  errorMessage?: ReactNode;
+  containerClassName?: string;
+  helperClassName?: string;
+  errorClassName?: string;
+  labelProps?: Omit<ComponentProps<typeof Label>, 'children' | 'htmlFor'>;
+};
+
+const FormField = forwardRef<HTMLInputElement, FormFieldProps>(
+  (
+    {
+      id,
+      label,
+      helperText,
+      errorMessage,
+      containerClassName,
+      helperClassName,
+      errorClassName,
+      labelProps,
+      variant,
+      className,
+      'aria-describedby': ariaDescribedBy,
+      'aria-invalid': ariaInvalid,
+      ...inputProps
+    },
+    ref
+  ) => {
+    const generatedId = useId();
+    const inputId = id ?? generatedId;
+    const helperId = helperText ? `${inputId}-helper` : undefined;
+    const errorId = errorMessage ? `${inputId}-error` : undefined;
+    const describedBy = [ariaDescribedBy, helperId, errorId].filter(Boolean).join(' ') || undefined;
+    const hasError = Boolean(errorMessage || ariaInvalid === true || ariaInvalid === 'true');
+    const { className: labelClassName, ...restLabelProps } = labelProps ?? {};
+
+    return (
+      <div className={cn('space-y-2', containerClassName)}>
+        <Label
+          htmlFor={inputId}
+          className={cn(hasError && 'text-destructive', labelClassName)}
+          {...restLabelProps}
+        >
+          {label}
+        </Label>
+
+        <Input
+          ref={ref}
+          id={inputId}
+          variant={hasError ? 'destructive' : variant}
+          className={className}
+          aria-invalid={hasError || ariaInvalid}
+          aria-describedby={describedBy}
+          {...inputProps}
+        />
+
+        {helperText ? (
+          <p id={helperId} className={cn('text-xs text-muted-foreground', helperClassName)}>
+            {helperText}
+          </p>
+        ) : null}
+
+        {errorMessage ? (
+          <p id={errorId} className={cn('text-xs text-destructive', errorClassName)}>
+            {errorMessage}
+          </p>
+        ) : null}
+      </div>
+    );
+  }
+);
+
+FormField.displayName = 'FormField';
+
+export { FormField };
+export type { FormFieldProps };


### PR DESCRIPTION
## Summary

Adds four new UI primitives — `Textarea`, `Spinner`, `Alert`, and `FormField` — to establish consistent loading states, inline messaging, multi-line input, and accessible form composition across the application. These fill gaps in the component library and are built to match existing `Input` variant conventions.

## Related Issue

Closes #446
Closes #447
Closes #448
Closes #449

## What Was Implemented

- [x] **`components/atoms/Textarea.tsx`** — Multi-line input with same 6 variants as `Input` (`default`, `primary`, `accent`, `success`, `destructive`, `ghost`), sizing variants (`sm`, `md`, `lg`), configurable resize behavior, `error` prop, `aria-invalid` wiring, `forwardRef`, and exported `TextareaProps`
- [x] **`components/atoms/Spinner.tsx`** — Loading indicator with size variants (`sm`, `md`, `lg`), Stellar color variants (`primary`, `accent`, `success`, `destructive`, `muted`), `motion-reduce:animate-none` for reduced-motion support, `role="status"` + `sr-only` screen-reader text, and exported `SpinnerProps`
- [x] **`components/atoms/Alert.tsx`** — Inline messaging atom with four variants (`info`, `success`, `warning`, `destructive`), optional Lucide icon slot, composable `AlertTitle` and `AlertDescription` sub-components, automatic `role="alert"` / `role="status"` resolution based on severity, and exported `AlertProps`
- [x] **`components/molecules/FormField.tsx`** — Composes `Label` + `Input` with helper text and error message slots, auto-generated IDs via `useId`, `aria-describedby` linking helper/error text, `aria-invalid` propagation, and exported `FormFieldProps`

## Implementation Details

- **Variant parity**: `Textarea` variants map 1-to-1 with `Input` using the same Stellar design tokens so both are interchangeable in form layouts
- **Error state layering**: `Textarea` and `FormField` both accept an `error` boolean alongside `aria-invalid` — normalised to a single `hasError` boolean
- **Alert role resolution**: `warning` and `destructive` auto-assign `role="alert"` + `aria-live="assertive"`; `info` and `success` use `role="status"` + `aria-live="polite"`. Overridable via the `role` prop
- **FormField ID management**: `useId` generates a stable ID when none is provided; `helperId` and `errorId` are derived from it and included in `aria-describedby` only when those slots are populated
- **CVA throughout**: All atoms use `class-variance-authority` consistent with existing `Input`, `Button`, and `Badge` atoms

## Screenshots / Recordings

_Atom/molecule additions with no page-level changes — visual verification via the steps below._

## How to Test

1. Render each `Textarea` variant and confirm border/focus-ring colours match the `Input` equivalents
2. Render `Spinner` at all size/variant combos; enable "Emulate prefers-reduced-motion" in DevTools → confirm animation stops
3. Render all four `Alert` variants with an icon + `AlertTitle` + `AlertDescription` → confirm correct colours and screen reader announcement
4. Render `FormField` with `label`, `helperText`, and `errorMessage` → inspect DOM for correct `aria-describedby` and `aria-invalid` attributes
5. Tab through all components and confirm keyboard focus is visible and logical

## Checklist

- [x] My code follows the atomic commit convention
- [x] Each commit message follows Conventional Commits (`feat:`, `fix:`, etc.)
- [x] I have performed a self-review of my code
- [x] My changes build successfully (`pnpm build`)
- [x] My changes pass linting (`pnpm lint`)
- [ ] I have added/updated relevant documentation
- [x] New components follow the atomic design pattern (atoms → molecules → organisms)
- [x] UI changes are responsive and tested on mobile viewports
- [ ] I have added screenshots/recordings for UI changes
