### PR TITLE
feat: add SSE endpoint for real-time tree status updates

### DIFF
--- a/app/api/trees/status/route.ts
+++ b/app/api/trees/status/route.ts
@@ -1,0 +1,76 @@
+import { type NextRequest } from 'next/server';
+import { TreeStatusPoller } from '@/lib/tree-status/poller';
+import type { TreeStatusEvent } from '@/lib/tree-status/types';
+
+export const runtime = 'nodejs';
+
+function sseSerialize(event: string, data: TreeStatusEvent): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+export async function GET(request: NextRequest) {
+  const poller = new TreeStatusPoller(3000);
+
+  let closed = false;
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let keepAliveTimer: ReturnType<typeof setInterval> | null = null;
+
+  function cleanup() {
+    closed = true;
+    if (pollTimer) clearInterval(pollTimer);
+    if (keepAliveTimer) clearInterval(keepAliveTimer);
+  }
+
+  request.signal.addEventListener('abort', cleanup);
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const send = (event: string, data: TreeStatusEvent) => {
+        try {
+          controller.enqueue(new TextEncoder().encode(sseSerialize(event, data)));
+        } catch {
+          cleanup();
+        }
+      };
+
+      const poll = async () => {
+        if (closed) return;
+        try {
+          const events = await poller.poll();
+          for (const event of events) {
+            send('tree-status', event);
+          }
+        } catch (err) {
+          console.error('[sse/trees/status] poll error:', err);
+        }
+      };
+
+      keepAliveTimer = setInterval(() => {
+        if (closed) {
+          cleanup();
+          return;
+        }
+        try {
+          controller.enqueue(new TextEncoder().encode(': keepalive\n\n'));
+        } catch {
+          cleanup();
+        }
+      }, 15_000);
+
+      pollTimer = setInterval(poll, 3000);
+
+      poll();
+    },
+    cancel() {
+      cleanup();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+    },
+  });
+}

--- a/hooks/useTreeStatus.ts
+++ b/hooks/useTreeStatus.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import type { TreeStatusEvent } from '@/lib/tree-status/types';
+
+interface UseTreeStatusOptions {
+  onEvent?: (event: TreeStatusEvent) => void;
+}
+
+interface UseTreeStatusReturn {
+  events: TreeStatusEvent[];
+  isConnected: boolean;
+  error: Event | null;
+}
+
+export function useTreeStatus(options: UseTreeStatusOptions = {}): UseTreeStatusReturn {
+  const [events, setEvents] = useState<TreeStatusEvent[]>([]);
+  const [isConnected, setIsConnected] = useState(false);
+  const [error, setError] = useState<Event | null>(null);
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const onEventRef = useRef(options.onEvent);
+  onEventRef.current = options.onEvent;
+
+  useEffect(() => {
+    const es = new EventSource('/api/trees/status');
+    eventSourceRef.current = es;
+
+    es.onopen = () => setIsConnected(true);
+
+    es.addEventListener('tree-status', (e: MessageEvent) => {
+      try {
+        const data: TreeStatusEvent = JSON.parse(e.data);
+        setEvents((prev) => [data, ...prev]);
+        onEventRef.current?.(data);
+      } catch {
+        // ignore malformed events
+      }
+    });
+
+    es.onerror = (err) => {
+      setError(err);
+      setIsConnected(false);
+    };
+
+    return () => {
+      es.close();
+      eventSourceRef.current = null;
+    };
+  }, []);
+
+  const clearEvents = useCallback(() => setEvents([]), []);
+
+  return { events, isConnected, error, clearEvents } as UseTreeStatusReturn & { clearEvents: () => void };
+}

--- a/lib/indexer/upsert.ts
+++ b/lib/indexer/upsert.ts
@@ -1,6 +1,13 @@
 import type { Pool } from 'pg';
 import type { ClassifiedTx } from '@/lib/indexer/classify';
 
+const TREE_TX_TYPES = new Set([
+  'escrow_deposit',
+  'escrow_planting',
+  'escrow_survival',
+  'escrow_refund',
+]);
+
 export interface IndexedTxRow {
   txHash: string;
   ledger: number;
@@ -38,6 +45,14 @@ export async function upsertTransaction(
       JSON.stringify(row.raw),
     ]
   );
+
+  if (TREE_TX_TYPES.has(classified.txType)) {
+    try {
+      await pool.query("SELECT pg_notify('tree_status_update', $1)", [row.txHash]);
+    } catch {
+      // NOTIFY is best-effort
+    }
+  }
 }
 
 /** Persist the latest paging token so the worker can resume after restart. */

--- a/lib/tree-status/poller.ts
+++ b/lib/tree-status/poller.ts
@@ -1,0 +1,74 @@
+import { getPool } from '@/lib/db/client';
+import { TREE_TX_TYPES, classifyTreeEvent, type TreeStatusEvent } from './types';
+
+interface TreeTxRow {
+  tx_hash: string;
+  created_at: string;
+  tx_type: string;
+  amount: string | null;
+  source_account: string | null;
+  destination: string | null;
+}
+
+export class TreeStatusPoller {
+  private lastTxHash: string | null = null;
+  private pollIntervalMs: number;
+
+  constructor(pollIntervalMs = 3000) {
+    this.pollIntervalMs = pollIntervalMs;
+  }
+
+  setLastTxHash(hash: string | null) {
+    this.lastTxHash = hash;
+  }
+
+  async poll(): Promise<TreeStatusEvent[]> {
+    const pool = getPool();
+    const placeholders = TREE_TX_TYPES.map((_, i) => `$${i + 1}`).join(',');
+    const values = TREE_TX_TYPES;
+
+    let sql: string;
+    const params: unknown[] = [];
+
+    if (this.lastTxHash) {
+      sql = `SELECT tx_hash, created_at, tx_type, amount, source_account, destination
+             FROM indexed_transactions
+             WHERE tx_type IN (${placeholders}) AND tx_hash > $${values.length + 1}
+             ORDER BY created_at ASC, tx_hash ASC`;
+      params.push(...values, this.lastTxHash);
+    } else {
+      sql = `SELECT tx_hash, created_at, tx_type, amount, source_account, destination
+             FROM indexed_transactions
+             WHERE tx_type IN (${placeholders})
+             ORDER BY created_at ASC, tx_hash ASC
+             LIMIT 100`;
+      params.push(...values);
+    }
+
+    const result = await pool.query<TreeTxRow>(sql, params);
+    const rows = result.rows;
+
+    if (rows.length === 0) return [];
+
+    this.lastTxHash = rows[rows.length - 1].tx_hash;
+
+    const events: TreeStatusEvent[] = [];
+
+    for (const row of rows) {
+      const eventType = classifyTreeEvent(row.tx_type);
+      if (!eventType) continue;
+
+      events.push({
+        id: row.tx_hash,
+        type: eventType,
+        transactionHash: row.tx_hash,
+        timestamp: row.created_at,
+        amount: row.amount,
+        sourceAccount: row.source_account,
+        destination: row.destination,
+      });
+    }
+
+    return events;
+  }
+}

--- a/lib/tree-status/types.ts
+++ b/lib/tree-status/types.ts
@@ -1,0 +1,30 @@
+export type TreeEventType =
+  | 'tree:funded'
+  | 'tree:planted'
+  | 'tree:survived'
+  | 'tree:disputed'
+  | 'tree:refunded';
+
+export interface TreeStatusEvent {
+  id: string;
+  type: TreeEventType;
+  transactionHash: string;
+  timestamp: string;
+  amount: string | null;
+  sourceAccount: string | null;
+  destination: string | null;
+}
+
+const TX_TYPE_MAP: Record<string, TreeEventType> = {
+  escrow_deposit: 'tree:funded',
+  escrow_planting: 'tree:planted',
+  escrow_survival: 'tree:survived',
+  escrow_refund: 'tree:refunded',
+};
+
+export const TREE_TX_TYPES = Object.keys(TX_TYPE_MAP);
+export const TREE_EVENT_TYPES_SET = new Set(TREE_TX_TYPES);
+
+export function classifyTreeEvent(txType: string): TreeEventType | null {
+  return TX_TYPE_MAP[txType] ?? null;
+}


### PR DESCRIPTION
Closes #553

---

## Summary

Implements a **Server-Sent Events (SSE)** endpoint at `GET /api/trees/status` that pushes tree status changes to connected browser clients in real time.

## Changes

### New Files
- **`app/api/trees/status/route.ts`** — SSE endpoint using `ReadableStream` with `text/event-stream` content type. Polls `indexed_transactions` every 3s for new tree-related transactions. Sends keepalive pings every 15s. Handles client disconnect gracefully.
- **`lib/tree-status/types.ts`** — Type definitions for tree status events with mapping from on-chain tx types.
- **`lib/tree-status/poller.ts`** — `TreeStatusPoller` class that queries `indexed_transactions` for escrow-related rows and returns typed events.
- **`hooks/useTreeStatus.ts`** — React client hook that connects to the SSE endpoint and collects events.

### Modified Files
- **`lib/indexer/upsert.ts`** — Indexer sends PostgreSQL `NOTIFY` on tree status changes.

## How It Works

1. Indexer streams on-chain Stellar txs → classifies tree events → inserts into `indexed_transactions` + sends `pg_notify`.
2. SSE endpoint polls DB every 3s for new tree events → pushes as SSE `tree-status` events.
3. Browser clients connect via `EventSource` and receive real-time updates.

## Client Usage

```typescript
import { useTreeStatus } from "@/hooks/useTreeStatus";

function TreeActivity() {
  const { events, isConnected } = useTreeStatus();
  return <div>{events.length} tree updates</div>;
}
```