### PR TITLE
feat(frontend): Search and filter - find trees by species, region, status

### DIFF
--- a/app/dashboard/trees/page.tsx
+++ b/app/dashboard/trees/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { Text } from '@/components/atoms/Text';
+import { SponsorTreeList } from '@/components/organisms/SponsorTreeList';
+import type { TreeFilterState, TreeSpecies, TreeStatus } from '@/lib/types/tree';
+import { TreePine } from 'lucide-react';
+
+function parseFiltersFromParams(searchParams: URLSearchParams): Partial<TreeFilterState> {
+  const species = searchParams.get('species');
+  const region = searchParams.get('region');
+  const status = searchParams.get('status');
+
+  return {
+    search: searchParams.get('search') || '',
+    species: (species as TreeSpecies) || 'all',
+    region: region || 'all',
+    status: (status as TreeStatus) || 'all',
+  };
+}
+
+function SponsorTreesPageContent() {
+  const searchParams = useSearchParams();
+  const initialFilters = parseFiltersFromParams(searchParams);
+
+  return (
+    <div className="container mx-auto max-w-6xl px-4 py-8">
+      <header className="mb-8">
+        <div className="mb-2 flex items-center gap-2">
+          <TreePine className="h-6 w-6 text-stellar-green" aria-hidden />
+          <Text variant="h2" as="h1">
+            My Trees
+          </Text>
+        </div>
+        <Text variant="muted" as="p">
+          Search and filter your sponsored trees by species, region, and planting status.
+        </Text>
+      </header>
+
+      <SponsorTreeList initialFilters={initialFilters} />
+    </div>
+  );
+}
+
+export default function SponsorTreesPage() {
+  return (
+    <Suspense fallback={<div className="container mx-auto px-4 py-8">Loading...</div>}>
+      <SponsorTreesPageContent />
+    </Suspense>
+  );
+}

--- a/app/impact/page.tsx
+++ b/app/impact/page.tsx
@@ -1,57 +1,6 @@
 import type { JSX } from 'react';
-
-import { TreePine, Wind, Users, Globe } from 'lucide-react';
-import { ImpactStatCard } from '@/components/atoms/ImpactStatCard';
-import { ImpactMapClient } from '@/components/organisms/ImpactMap/ImpactMapClient';
-import { IMPACT_DATA } from '@/lib/api/impactData';
-
-import { ImpactMapWrapper } from '@/components/organisms/ImpactMap/ImpactMapWrapper';
+import { ImpactExplorer } from '@/components/organisms/ImpactExplorer';
 
 export default function ImpactPage(): JSX.Element {
-  const { stats, regions } = IMPACT_DATA;
-
-  return (
-    <main className="mx-auto max-w-6xl px-4 py-12">
-      <div className="mb-10 text-center">
-        <h1 className="text-4xl font-bold tracking-tight">Our Impact</h1>
-        <p className="mt-2 text-muted-foreground">
-          Real-time planting activity across FarmCredit-supported regions.
-        </p>
-      </div>
-
-      {/* Stats grid */}
-      <div className="mb-10 grid grid-cols-2 gap-4 sm:grid-cols-4">
-        <ImpactStatCard
-          label="Trees Planted"
-          value={stats.treesPlanted.toLocaleString()}
-          icon={<TreePine className="h-5 w-5 text-[#00B36B]" aria-hidden />}
-        />
-        <ImpactStatCard
-          label="CO₂ Offset (tonnes)"
-          value={stats.co2OffsetTonnes.toLocaleString()}
-          icon={<Wind className="h-5 w-5 text-[#14B6E7]" aria-hidden />}
-        />
-        <ImpactStatCard
-          label="Farmers Supported"
-          value={stats.farmersSupported.toLocaleString()}
-          icon={<Users className="h-5 w-5 text-[#3E1BDB]" aria-hidden />}
-        />
-        <ImpactStatCard
-          label="Countries Reached"
-          value={stats.countriesReached.toString()}
-          icon={<Globe className="h-5 w-5 text-[#00C2FF]" aria-hidden />}
-        />
-      </div>
-
-      {/* Map */}
-      <div className="overflow-hidden rounded-xl border shadow-sm" style={{ height: '480px' }}>
-        <ImpactMapWrapper regions={regions} />
-        <ImpactMapClient regions={regions} />
-      </div>
-
-      <p className="mt-3 text-center text-xs text-muted-foreground">
-        Circles show aggregated region-level activity. Exact GPS coordinates are never displayed.
-      </p>
-    </main>
-  );
+  return <ImpactExplorer />;
 }

--- a/components/molecules/TreeFilterBar/TreeFilterBar.tsx
+++ b/components/molecules/TreeFilterBar/TreeFilterBar.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useCallback } from 'react';
+import { Input } from '@/components/atoms/Input';
+import { Select } from '@/components/atoms/Select';
+import { Button } from '@/components/atoms/Button';
+import { Text } from '@/components/atoms/Text';
+import type { TreeFilterBarProps } from '@/lib/types/tree';
+import { Search, X } from 'lucide-react';
+
+function formatStatus(status: string): string {
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+/**
+ * TreeFilterBar — search and filter controls for trees by species, region, and status.
+ * Requirements: Issue #539
+ */
+export function TreeFilterBar({
+  filters,
+  speciesOptions,
+  regionOptions,
+  statusOptions,
+  onFilterChange,
+}: TreeFilterBarProps) {
+  const handleSearchChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onFilterChange({ search: e.target.value });
+    },
+    [onFilterChange]
+  );
+
+  const handleClearSearch = useCallback(() => {
+    onFilterChange({ search: '' });
+  }, [onFilterChange]);
+
+  const hasActiveFilters =
+    filters.search ||
+    filters.species !== 'all' ||
+    filters.region !== 'all' ||
+    filters.status !== 'all';
+
+  return (
+    <div className="space-y-4">
+      <div className="relative">
+        <div className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
+          <Search className="h-4 w-4" aria-hidden="true" />
+        </div>
+        <Input
+          type="search"
+          placeholder="Search by tree ID, species, region, or project..."
+          value={filters.search}
+          onChange={handleSearchChange}
+          variant="primary"
+          className="pl-10 pr-10"
+          aria-label="Search trees"
+        />
+        {filters.search && (
+          <Button
+            onClick={handleClearSearch}
+            variant="ghost"
+            size="icon"
+            className="absolute right-1 top-1/2 -translate-y-1/2 h-8 w-8"
+            aria-label="Clear search"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div>
+          <label htmlFor="tree-species-filter" className="sr-only">
+            Filter by species
+          </label>
+          <Select
+            id="tree-species-filter"
+            variant="primary"
+            value={filters.species}
+            onChange={(e) => onFilterChange({ species: e.target.value as typeof filters.species })}
+            aria-label="Filter by species"
+          >
+            <option value="all">All Species</option>
+            {speciesOptions.map((species) => (
+              <option key={species} value={species}>
+                {species}
+              </option>
+            ))}
+          </Select>
+        </div>
+
+        <div>
+          <label htmlFor="tree-region-filter" className="sr-only">
+            Filter by region
+          </label>
+          <Select
+            id="tree-region-filter"
+            variant="primary"
+            value={filters.region}
+            onChange={(e) => onFilterChange({ region: e.target.value })}
+            aria-label="Filter by region"
+          >
+            <option value="all">All Regions</option>
+            {regionOptions.map((region) => (
+              <option key={region} value={region}>
+                {region}
+              </option>
+            ))}
+          </Select>
+        </div>
+
+        <div>
+          <label htmlFor="tree-status-filter" className="sr-only">
+            Filter by status
+          </label>
+          <Select
+            id="tree-status-filter"
+            variant="primary"
+            value={filters.status}
+            onChange={(e) => onFilterChange({ status: e.target.value as typeof filters.status })}
+            aria-label="Filter by status"
+          >
+            <option value="all">All Statuses</option>
+            {statusOptions.map((status) => (
+              <option key={status} value={status}>
+                {formatStatus(status)}
+              </option>
+            ))}
+          </Select>
+        </div>
+      </div>
+
+      {hasActiveFilters && (
+        <div className="flex flex-wrap items-center gap-2">
+          <Text variant="small" as="span" className="text-muted-foreground">
+            Active filters:
+          </Text>
+          {filters.species !== 'all' && (
+            <Button
+              onClick={() => onFilterChange({ species: 'all' })}
+              stellar="primary-outline"
+              size="sm"
+              className="h-7 text-xs"
+              aria-label={`Remove ${filters.species} filter`}
+            >
+              {filters.species}
+              <X className="ml-1 h-3 w-3" />
+            </Button>
+          )}
+          {filters.region !== 'all' && (
+            <Button
+              onClick={() => onFilterChange({ region: 'all' })}
+              stellar="primary-outline"
+              size="sm"
+              className="h-7 text-xs"
+              aria-label={`Remove ${filters.region} filter`}
+            >
+              {filters.region}
+              <X className="ml-1 h-3 w-3" />
+            </Button>
+          )}
+          {filters.status !== 'all' && (
+            <Button
+              onClick={() => onFilterChange({ status: 'all' })}
+              stellar="primary-outline"
+              size="sm"
+              className="h-7 text-xs"
+              aria-label={`Remove ${filters.status} filter`}
+            >
+              {formatStatus(filters.status)}
+              <X className="ml-1 h-3 w-3" />
+            </Button>
+          )}
+          {filters.search && (
+            <Button
+              onClick={handleClearSearch}
+              stellar="primary-outline"
+              size="sm"
+              className="h-7 text-xs"
+              aria-label="Clear search filter"
+            >
+              Search: &quot;
+              {filters.search.length > 20 ? `${filters.search.slice(0, 20)}...` : filters.search}
+              &quot;
+              <X className="ml-1 h-3 w-3" />
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/molecules/TreeFilterBar/index.ts
+++ b/components/molecules/TreeFilterBar/index.ts
@@ -1,0 +1,1 @@
+export { TreeFilterBar } from './TreeFilterBar';

--- a/components/molecules/TreeStatusBadge/TreeStatusBadge.tsx
+++ b/components/molecules/TreeStatusBadge/TreeStatusBadge.tsx
@@ -1,0 +1,18 @@
+import { Badge } from '@/components/atoms/Badge';
+import type { TreeStatus } from '@/lib/types/tree';
+
+const STATUS_CONFIG: Record<
+  TreeStatus,
+  { variant: 'default' | 'secondary' | 'destructive' | 'success'; label: string }
+> = {
+  funded: { variant: 'secondary', label: 'Funded' },
+  planted: { variant: 'default', label: 'Planted' },
+  verified: { variant: 'success', label: 'Verified' },
+  completed: { variant: 'success', label: 'Completed' },
+  failed: { variant: 'destructive', label: 'Failed' },
+};
+
+export function TreeStatusBadge({ status }: { status: TreeStatus }) {
+  const { variant, label } = STATUS_CONFIG[status];
+  return <Badge variant={variant}>{label}</Badge>;
+}

--- a/components/molecules/TreeStatusBadge/index.ts
+++ b/components/molecules/TreeStatusBadge/index.ts
@@ -1,0 +1,1 @@
+export { TreeStatusBadge } from './TreeStatusBadge';

--- a/components/organisms/DashboardOverview/QuickActions.tsx
+++ b/components/organisms/DashboardOverview/QuickActions.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/molecules/Card';
 import { Text } from '@/components/atoms/Text';
 import { cn } from '@/lib/utils';
-import { Heart, ShoppingCart, BarChart3, ArrowRight } from 'lucide-react';
+import { Heart, ShoppingCart, BarChart3, ArrowRight, TreePine } from 'lucide-react';
 
 export function QuickActions() {
   const router = useRouter();
@@ -31,6 +31,14 @@ export function QuickActions() {
       path: '/marketplace',
       color:
         'bg-stellar-blue/10 text-stellar-blue group-hover:bg-stellar-blue group-hover:text-white',
+    },
+    {
+      label: 'My Trees',
+      icon: <TreePine size={20} />,
+      description: 'Track your forest',
+      path: '/dashboard/trees',
+      color:
+        'bg-stellar-green/10 text-stellar-green group-hover:bg-stellar-green group-hover:text-white',
     },
     {
       label: 'View Portfolio',

--- a/components/organisms/ImpactExplorer/ImpactExplorer.tsx
+++ b/components/organisms/ImpactExplorer/ImpactExplorer.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { TreePine, Wind, Users, Globe } from 'lucide-react';
+import { ImpactStatCard } from '@/components/atoms/ImpactStatCard';
+import { TreeFilterBar } from '@/components/molecules/TreeFilterBar';
+import { Text } from '@/components/atoms/Text';
+import { ImpactMapClient } from '@/components/organisms/ImpactMap/ImpactMapClient';
+import { IMPACT_DATA } from '@/lib/api/impactData';
+import { fetchPublicTrees } from '@/lib/api/trees';
+import type { Tree, TreeFilterState, TreeSpecies, TreeStatus } from '@/lib/types/tree';
+
+const DEFAULT_FILTERS: TreeFilterState = {
+  search: '',
+  species: 'all',
+  region: 'all',
+  status: 'all',
+};
+
+/**
+ * Public impact explorer with tree search/filter and map markers.
+ * Requirements: Issue #539
+ */
+export function ImpactExplorer() {
+  const { stats, regions } = IMPACT_DATA;
+  const [filters, setFilters] = useState<TreeFilterState>(DEFAULT_FILTERS);
+  const [trees, setTrees] = useState<Tree[]>([]);
+  const [speciesOptions, setSpeciesOptions] = useState<TreeSpecies[]>([]);
+  const [regionOptions, setRegionOptions] = useState<string[]>([]);
+  const [statusOptions, setStatusOptions] = useState<TreeStatus[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const loadTrees = useCallback(async (nextFilters: TreeFilterState) => {
+    setIsLoading(true);
+    try {
+      const response = await fetchPublicTrees(nextFilters);
+      setTrees(response.trees);
+      setSpeciesOptions(response.speciesOptions);
+      setRegionOptions(response.regionOptions);
+      setStatusOptions(response.statusOptions);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadTrees(filters);
+  }, [filters, loadTrees]);
+
+  const updateFilters = useCallback((partial: Partial<TreeFilterState>) => {
+    setFilters((prev) => ({ ...prev, ...partial }));
+  }, []);
+
+  const filteredRegions = useMemo(() => {
+    if (filters.region === 'all') return regions;
+    return regions.filter((r) => r.name === filters.region);
+  }, [filters.region, regions]);
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-12">
+      <div className="mb-10 text-center">
+        <h1 className="text-4xl font-bold tracking-tight">Our Impact</h1>
+        <p className="mt-2 text-muted-foreground">
+          Real-time planting activity across FarmCredit-supported regions.
+        </p>
+      </div>
+
+      <div className="mb-10 grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <ImpactStatCard
+          label="Trees Planted"
+          value={stats.treesPlanted.toLocaleString()}
+          icon={<TreePine className="h-5 w-5 text-[#00B36B]" aria-hidden />}
+        />
+        <ImpactStatCard
+          label="CO₂ Offset (tonnes)"
+          value={stats.co2OffsetTonnes.toLocaleString()}
+          icon={<Wind className="h-5 w-5 text-[#14B6E7]" aria-hidden />}
+        />
+        <ImpactStatCard
+          label="Farmers Supported"
+          value={stats.farmersSupported.toLocaleString()}
+          icon={<Users className="h-5 w-5 text-[#3E1BDB]" aria-hidden />}
+        />
+        <ImpactStatCard
+          label="Countries Reached"
+          value={stats.countriesReached.toString()}
+          icon={<Globe className="h-5 w-5 text-[#00C2FF]" aria-hidden />}
+        />
+      </div>
+
+      <div className="mb-6">
+        <TreeFilterBar
+          filters={filters}
+          speciesOptions={speciesOptions}
+          regionOptions={regionOptions}
+          statusOptions={statusOptions}
+          onFilterChange={updateFilters}
+        />
+      </div>
+
+      <Text variant="muted" as="p" className="mb-4" aria-live="polite">
+        {isLoading
+          ? 'Loading map data...'
+          : trees.length === 0
+            ? 'No trees match your filters on the map'
+            : `Showing ${trees.length} ${trees.length === 1 ? 'tree' : 'trees'} on the map`}
+      </Text>
+
+      <div className="overflow-hidden rounded-xl border shadow-sm" style={{ height: '480px' }}>
+        <ImpactMapClient regions={filteredRegions} trees={trees} />
+      </div>
+
+      <p className="mt-3 text-center text-xs text-muted-foreground">
+        Large circles show region-level aggregates. Small markers show individual trees with fuzzed
+        coordinates — exact GPS is never displayed.
+      </p>
+    </main>
+  );
+}

--- a/components/organisms/ImpactExplorer/index.ts
+++ b/components/organisms/ImpactExplorer/index.ts
@@ -1,0 +1,1 @@
+export { ImpactExplorer } from './ImpactExplorer';

--- a/components/organisms/ImpactMap/ImpactMap.tsx
+++ b/components/organisms/ImpactMap/ImpactMap.tsx
@@ -3,19 +3,31 @@
 import { useEffect, type JSX } from 'react';
 import { MapContainer, TileLayer, CircleMarker, Tooltip } from 'react-leaflet';
 import type { RegionMarker } from '@/lib/api/impactData';
+import type { Tree, TreeStatus } from '@/lib/types/tree';
 import 'leaflet/dist/leaflet.css';
 
 interface ImpactMapProps {
   regions: RegionMarker[];
+  trees?: Tree[];
 }
 
 function radiusForTrees(trees: number): number {
   return 8 + Math.min(trees / 40_000, 1) * 32;
 }
 
-export function ImpactMap({ regions }: ImpactMapProps): JSX.Element {
+function colorForStatus(status: TreeStatus): { fill: string; stroke: string } {
+  const colors: Record<TreeStatus, { fill: string; stroke: string }> = {
+    funded: { fill: '#94a3b8', stroke: '#64748b' },
+    planted: { fill: '#14B6E7', stroke: '#0ea5e9' },
+    verified: { fill: '#00B36B', stroke: '#059669' },
+    completed: { fill: '#3E1BDB', stroke: '#4f46e5' },
+    failed: { fill: '#ef4444', stroke: '#dc2626' },
+  };
+  return colors[status];
+}
+
+export function ImpactMap({ regions, trees = [] }: ImpactMapProps): JSX.Element {
   useEffect(() => {
-    // Fix Leaflet default icon path issue in Next.js
     void import('leaflet').then((L) => {
       // @ts-expect-error — Leaflet internal
       delete L.Icon.Default.prototype._getIconUrl;
@@ -47,7 +59,7 @@ export function ImpactMap({ regions }: ImpactMapProps): JSX.Element {
           pathOptions={{
             color: '#14B6E7',
             fillColor: '#00B36B',
-            fillOpacity: 0.55,
+            fillOpacity: 0.35,
             weight: 2,
           }}
         >
@@ -60,6 +72,30 @@ export function ImpactMap({ regions }: ImpactMapProps): JSX.Element {
           </Tooltip>
         </CircleMarker>
       ))}
+      {trees.map((tree) => {
+        const colors = colorForStatus(tree.status);
+        return (
+          <CircleMarker
+            key={tree.id}
+            center={[tree.lat, tree.lng]}
+            radius={6}
+            pathOptions={{
+              color: colors.stroke,
+              fillColor: colors.fill,
+              fillOpacity: 0.85,
+              weight: 2,
+            }}
+          >
+            <Tooltip>
+              <strong>{tree.treeId}</strong>
+              <br />
+              {tree.species} · {tree.region}
+              <br />
+              Status: {tree.status}
+            </Tooltip>
+          </CircleMarker>
+        );
+      })}
     </MapContainer>
   );
 }

--- a/components/organisms/ImpactMap/ImpactMapClient.tsx
+++ b/components/organisms/ImpactMap/ImpactMapClient.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from 'next/dynamic';
 import type { RegionMarker } from '@/lib/api/impactData';
+import type { Tree } from '@/lib/types/tree';
 
 const ImpactMapInner = dynamic(
   () => import('@/components/organisms/ImpactMap/ImpactMap').then((m) => m.ImpactMap),
@@ -11,6 +12,12 @@ const ImpactMapInner = dynamic(
   }
 );
 
-export function ImpactMapClient({ regions }: { regions: RegionMarker[] }) {
-  return <ImpactMapInner regions={regions} />;
+export function ImpactMapClient({
+  regions,
+  trees = [],
+}: {
+  regions: RegionMarker[];
+  trees?: Tree[];
+}) {
+  return <ImpactMapInner regions={regions} trees={trees} />;
 }

--- a/components/organisms/SponsorTreeList/SponsorTreeList.tsx
+++ b/components/organisms/SponsorTreeList/SponsorTreeList.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { TreePine, MapPin, Leaf } from 'lucide-react';
+import { TreeFilterBar } from '@/components/molecules/TreeFilterBar';
+import { TreeStatusBadge } from '@/components/molecules/TreeStatusBadge';
+import { Text } from '@/components/atoms/Text';
+import { Skeleton } from '@/components/atoms/Skeleton';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/molecules/Card';
+import { useSponsorTrees } from '@/hooks/useSponsorTrees';
+import type { TreeFilterState } from '@/lib/types/tree';
+
+function fmtDate(iso?: string) {
+  if (!iso) return 'Not yet planted';
+  return new Date(iso).toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+interface SponsorTreeListProps {
+  initialFilters?: Partial<TreeFilterState>;
+}
+
+/**
+ * Sponsor tree portfolio with search and filter by species, region, and status.
+ * Requirements: Issue #539
+ */
+export function SponsorTreeList({ initialFilters }: SponsorTreeListProps) {
+  const {
+    trees,
+    filters,
+    speciesOptions,
+    regionOptions,
+    statusOptions,
+    totalCount,
+    isLoading,
+    error,
+    updateFilters,
+  } = useSponsorTrees(initialFilters);
+
+  return (
+    <div className="space-y-6">
+      <TreeFilterBar
+        filters={filters}
+        speciesOptions={speciesOptions}
+        regionOptions={regionOptions}
+        statusOptions={statusOptions}
+        onFilterChange={updateFilters}
+      />
+
+      <Text variant="muted" as="p" aria-live="polite">
+        {isLoading
+          ? 'Loading trees...'
+          : totalCount === 0
+            ? 'No trees match your filters'
+            : `Showing ${totalCount} ${totalCount === 1 ? 'tree' : 'trees'}`}
+      </Text>
+
+      {error && (
+        <Text variant="small" className="text-destructive" role="alert">
+          {error}
+        </Text>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <TreePine className="h-5 w-5 text-stellar-green" aria-hidden />
+            My Forest
+          </CardTitle>
+          <CardDescription>
+            Track every tree you have sponsored — species, region, planting status, and CO₂ impact.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-0">
+          {isLoading ? (
+            <div className="space-y-4 p-6">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-20 w-full rounded-xl" />
+              ))}
+            </div>
+          ) : trees.length === 0 ? (
+            <div className="p-10 text-center">
+              <Text variant="muted">Try adjusting your search or filters to find trees.</Text>
+            </div>
+          ) : (
+            <ul className="divide-y" role="list">
+              {trees.map((tree) => (
+                <li key={tree.id} className="px-6 py-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="space-y-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Text className="font-semibold">{tree.treeId}</Text>
+                        <TreeStatusBadge status={tree.status} />
+                      </div>
+                      <Text className="text-muted-foreground">{tree.projectName}</Text>
+                      <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+                        <span className="inline-flex items-center gap-1">
+                          <Leaf className="h-3.5 w-3.5" aria-hidden />
+                          {tree.species}
+                        </span>
+                        <span className="inline-flex items-center gap-1">
+                          <MapPin className="h-3.5 w-3.5" aria-hidden />
+                          {tree.region}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="text-right text-sm">
+                      <Text className="font-medium text-stellar-green">
+                        ~{tree.co2OffsetKgPerYear} kg CO₂/yr
+                      </Text>
+                      <Text className="text-muted-foreground">{fmtDate(tree.plantedAt)}</Text>
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/organisms/SponsorTreeList/index.ts
+++ b/components/organisms/SponsorTreeList/index.ts
@@ -1,0 +1,1 @@
+export { SponsorTreeList } from './SponsorTreeList';

--- a/hooks/useSponsorTrees.ts
+++ b/hooks/useSponsorTrees.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { fetchTrees } from '@/lib/api/trees';
+import type { Tree, TreeFilterState, TreeSpecies, TreeStatus } from '@/lib/types/tree';
+
+const DEFAULT_FILTERS: TreeFilterState = {
+  search: '',
+  species: 'all',
+  region: 'all',
+  status: 'all',
+};
+
+export function useSponsorTrees(initialFilters: Partial<TreeFilterState> = {}) {
+  const [filters, setFilters] = useState<TreeFilterState>({
+    ...DEFAULT_FILTERS,
+    ...initialFilters,
+  });
+  const [trees, setTrees] = useState<Tree[]>([]);
+  const [speciesOptions, setSpeciesOptions] = useState<TreeSpecies[]>([]);
+  const [regionOptions, setRegionOptions] = useState<string[]>([]);
+  const [statusOptions, setStatusOptions] = useState<TreeStatus[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadTrees = useCallback(async (nextFilters: TreeFilterState) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await fetchTrees(nextFilters);
+      setTrees(response.trees);
+      setSpeciesOptions(response.speciesOptions);
+      setRegionOptions(response.regionOptions);
+      setStatusOptions(response.statusOptions);
+    } catch {
+      setError('Failed to load your trees. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadTrees(filters);
+  }, [filters, loadTrees]);
+
+  const updateFilters = useCallback((partial: Partial<TreeFilterState>) => {
+    setFilters((prev) => ({ ...prev, ...partial }));
+  }, []);
+
+  const totalCount = useMemo(() => trees.length, [trees]);
+
+  return {
+    trees,
+    filters,
+    speciesOptions,
+    regionOptions,
+    statusOptions,
+    totalCount,
+    isLoading,
+    error,
+    updateFilters,
+    setFilters,
+  };
+}

--- a/lib/api/mock/trees.ts
+++ b/lib/api/mock/trees.ts
@@ -1,0 +1,222 @@
+import { TREE_SPECIES } from '@/lib/constants/species';
+import type { Tree, TreeFilterState, TreesResponse } from '@/lib/types/tree';
+
+const co2BySpecies = Object.fromEntries(
+  TREE_SPECIES.map((s) => [s.name, s.co2KgPerYear])
+) as Record<Tree['species'], number>;
+
+/** Fuzzed coordinates — region-centred, never exact planter GPS. */
+const MOCK_TREES: Tree[] = [
+  {
+    id: 'tree-001',
+    treeId: 'HRV-2024-0001',
+    species: 'Teak',
+    region: 'Kano, Nigeria',
+    status: 'verified',
+    plantedAt: '2024-03-12T08:00:00Z',
+    lat: 12.04,
+    lng: 8.48,
+    co2OffsetKgPerYear: co2BySpecies.Teak,
+    projectName: 'Northern Savanna Reforestation',
+  },
+  {
+    id: 'tree-002',
+    treeId: 'HRV-2024-0002',
+    species: 'Moringa',
+    region: 'Kano, Nigeria',
+    status: 'planted',
+    plantedAt: '2024-05-20T10:30:00Z',
+    lat: 11.98,
+    lng: 8.55,
+    co2OffsetKgPerYear: co2BySpecies.Moringa,
+    projectName: 'Northern Savanna Reforestation',
+  },
+  {
+    id: 'tree-003',
+    treeId: 'HRV-2024-0003',
+    species: 'Eucalyptus',
+    region: 'Kaduna, Nigeria',
+    status: 'completed',
+    plantedAt: '2023-11-05T14:00:00Z',
+    lat: 10.48,
+    lng: 7.4,
+    co2OffsetKgPerYear: co2BySpecies.Eucalyptus,
+    projectName: 'Central Belt Afforestation',
+  },
+  {
+    id: 'tree-004',
+    treeId: 'HRV-2024-0004',
+    species: 'Mangrove',
+    region: 'Greater Accra, Ghana',
+    status: 'verified',
+    plantedAt: '2024-01-18T09:15:00Z',
+    lat: 5.58,
+    lng: -0.18,
+    co2OffsetKgPerYear: co2BySpecies.Mangrove,
+    projectName: 'Coastal Mangrove Recovery',
+  },
+  {
+    id: 'tree-005',
+    treeId: 'HRV-2024-0005',
+    species: 'Teak',
+    region: 'Kaduna, Nigeria',
+    status: 'funded',
+    lat: 10.55,
+    lng: 7.5,
+    co2OffsetKgPerYear: co2BySpecies.Teak,
+    projectName: 'Central Belt Afforestation',
+  },
+  {
+    id: 'tree-006',
+    treeId: 'HRV-2024-0006',
+    species: 'Moringa',
+    region: 'Sokoto, Nigeria',
+    status: 'planted',
+    plantedAt: '2024-06-02T07:45:00Z',
+    lat: 13.02,
+    lng: 5.28,
+    co2OffsetKgPerYear: co2BySpecies.Moringa,
+    projectName: 'Sahel Green Belt',
+  },
+  {
+    id: 'tree-007',
+    treeId: 'HRV-2024-0007',
+    species: 'Eucalyptus',
+    region: 'Nairobi, Kenya',
+    status: 'verified',
+    plantedAt: '2024-02-28T11:00:00Z',
+    lat: -1.27,
+    lng: 36.78,
+    co2OffsetKgPerYear: co2BySpecies.Eucalyptus,
+    projectName: 'East Africa Urban Greening',
+  },
+  {
+    id: 'tree-008',
+    treeId: 'HRV-2024-0008',
+    species: 'Mangrove',
+    region: 'Kampala, Uganda',
+    status: 'failed',
+    plantedAt: '2023-09-14T16:20:00Z',
+    lat: 0.3,
+    lng: 32.55,
+    co2OffsetKgPerYear: co2BySpecies.Mangrove,
+    projectName: 'Lake Victoria Watershed',
+  },
+  {
+    id: 'tree-009',
+    treeId: 'HRV-2024-0009',
+    species: 'Teak',
+    region: 'Niger State, Nigeria',
+    status: 'completed',
+    plantedAt: '2023-07-22T08:30:00Z',
+    lat: 9.9,
+    lng: 5.65,
+    co2OffsetKgPerYear: co2BySpecies.Teak,
+    projectName: 'Middle Belt Restoration',
+  },
+  {
+    id: 'tree-010',
+    treeId: 'HRV-2024-0010',
+    species: 'Moringa',
+    region: 'Greater Accra, Ghana',
+    status: 'funded',
+    lat: 5.62,
+    lng: -0.22,
+    co2OffsetKgPerYear: co2BySpecies.Moringa,
+    projectName: 'Coastal Mangrove Recovery',
+  },
+  {
+    id: 'tree-011',
+    treeId: 'HRV-2024-0011',
+    species: 'Eucalyptus',
+    region: 'Sokoto, Nigeria',
+    status: 'planted',
+    plantedAt: '2024-04-10T13:00:00Z',
+    lat: 13.08,
+    lng: 5.2,
+    co2OffsetKgPerYear: co2BySpecies.Eucalyptus,
+    projectName: 'Sahel Green Belt',
+  },
+  {
+    id: 'tree-012',
+    treeId: 'HRV-2024-0012',
+    species: 'Mangrove',
+    region: 'Kano, Nigeria',
+    status: 'verified',
+    plantedAt: '2024-03-30T10:00:00Z',
+    lat: 12.02,
+    lng: 8.5,
+    co2OffsetKgPerYear: co2BySpecies.Mangrove,
+    projectName: 'Northern Savanna Reforestation',
+  },
+  {
+    id: 'tree-013',
+    treeId: 'HRV-2024-0013',
+    species: 'Teak',
+    region: 'Nairobi, Kenya',
+    status: 'planted',
+    plantedAt: '2024-05-15T09:30:00Z',
+    lat: -1.31,
+    lng: 36.85,
+    co2OffsetKgPerYear: co2BySpecies.Teak,
+    projectName: 'East Africa Urban Greening',
+  },
+  {
+    id: 'tree-014',
+    treeId: 'HRV-2024-0014',
+    species: 'Moringa',
+    region: 'Kampala, Uganda',
+    status: 'verified',
+    plantedAt: '2024-01-08T12:00:00Z',
+    lat: 0.34,
+    lng: 32.6,
+    co2OffsetKgPerYear: co2BySpecies.Moringa,
+    projectName: 'Lake Victoria Watershed',
+  },
+  {
+    id: 'tree-015',
+    treeId: 'HRV-2024-0015',
+    species: 'Eucalyptus',
+    region: 'Niger State, Nigeria',
+    status: 'funded',
+    lat: 9.96,
+    lng: 5.58,
+    co2OffsetKgPerYear: co2BySpecies.Eucalyptus,
+    projectName: 'Middle Belt Restoration',
+  },
+];
+
+export function getMockTrees(): Tree[] {
+  return MOCK_TREES;
+}
+
+export function getMockTreesResponse(filters: TreeFilterState): TreesResponse {
+  const allTrees = getMockTrees();
+  const filtered = filterTrees(allTrees, filters);
+
+  return {
+    trees: filtered,
+    speciesOptions: [...new Set(allTrees.map((t) => t.species))].sort(),
+    regionOptions: [...new Set(allTrees.map((t) => t.region))].sort(),
+    statusOptions: [...new Set(allTrees.map((t) => t.status))].sort(),
+    totalCount: filtered.length,
+  };
+}
+
+export function filterTrees(trees: Tree[], filters: TreeFilterState): Tree[] {
+  const query = filters.search.trim().toLowerCase();
+
+  return trees.filter((tree) => {
+    if (filters.species !== 'all' && tree.species !== filters.species) return false;
+    if (filters.region !== 'all' && tree.region !== filters.region) return false;
+    if (filters.status !== 'all' && tree.status !== filters.status) return false;
+
+    if (!query) return true;
+
+    const haystack = [tree.treeId, tree.species, tree.region, tree.status, tree.projectName]
+      .join(' ')
+      .toLowerCase();
+
+    return haystack.includes(query);
+  });
+}

--- a/lib/api/trees.ts
+++ b/lib/api/trees.ts
@@ -1,0 +1,11 @@
+import { getMockTreesResponse } from '@/lib/api/mock/trees';
+import type { TreeFilterState, TreesResponse } from '@/lib/types/tree';
+
+export async function fetchTrees(filters: TreeFilterState): Promise<TreesResponse> {
+  await new Promise((resolve) => setTimeout(resolve, 150));
+  return getMockTreesResponse(filters);
+}
+
+export function fetchPublicTrees(filters: TreeFilterState): Promise<TreesResponse> {
+  return fetchTrees(filters);
+}

--- a/lib/constants/species.ts
+++ b/lib/constants/species.ts
@@ -1,0 +1,16 @@
+import type { TreeSpecies } from '@/lib/types/tree';
+
+export interface SpeciesInfo {
+  name: TreeSpecies;
+  co2KgPerYear: number;
+  maturityYears: number;
+}
+
+export const TREE_SPECIES: SpeciesInfo[] = [
+  { name: 'Teak', co2KgPerYear: 22, maturityYears: 20 },
+  { name: 'Moringa', co2KgPerYear: 9, maturityYears: 3 },
+  { name: 'Eucalyptus', co2KgPerYear: 31, maturityYears: 10 },
+  { name: 'Mangrove', co2KgPerYear: 14, maturityYears: 15 },
+];
+
+export const TREE_SPECIES_NAMES = TREE_SPECIES.map((s) => s.name);

--- a/lib/types/tree.ts
+++ b/lib/types/tree.ts
@@ -1,0 +1,39 @@
+export type TreeSpecies = 'Teak' | 'Moringa' | 'Eucalyptus' | 'Mangrove';
+
+export type TreeStatus = 'funded' | 'planted' | 'verified' | 'completed' | 'failed';
+
+export interface Tree {
+  id: string;
+  treeId: string;
+  species: TreeSpecies;
+  region: string;
+  status: TreeStatus;
+  plantedAt?: string;
+  lat: number;
+  lng: number;
+  co2OffsetKgPerYear: number;
+  projectName: string;
+}
+
+export interface TreeFilterState {
+  search: string;
+  species: TreeSpecies | 'all';
+  region: string | 'all';
+  status: TreeStatus | 'all';
+}
+
+export interface TreeFilterBarProps {
+  filters: TreeFilterState;
+  speciesOptions: TreeSpecies[];
+  regionOptions: string[];
+  statusOptions: TreeStatus[];
+  onFilterChange: (filters: Partial<TreeFilterState>) => void;
+}
+
+export interface TreesResponse {
+  trees: Tree[];
+  speciesOptions: TreeSpecies[];
+  regionOptions: string[];
+  statusOptions: TreeStatus[];
+  totalCount: number;
+}


### PR DESCRIPTION
## Summary
- Adds search and filter controls for sponsored trees by species, region, and status on a new sponsor dashboard page at `/dashboard/trees`
- Extends the public `/impact` map with the same filters and individual tree markers (fuzzed coordinates)
- Introduces tree types, species constants, mock data, `TreeFilterBar`, `SponsorTreeList`, and `useSponsorTrees` hook

Closes #539

## Test plan
- [ ] Open `/dashboard/trees` and verify the tree list loads
- [ ] Filter by species (e.g. Mangrove), region (e.g. Kano, Nigeria), and status (e.g. Verified)
- [ ] Search by tree ID (e.g. `HRV-2024-0001`) and confirm results update
- [ ] Open `/impact` and apply the same filters; confirm map markers update
- [ ] Confirm Quick Actions includes a My Trees link on the dashboard
- [ ] Run `npx tsc --noEmit` and confirm no type errors
