### PR TITLE
feat(frontend): dark mode with system preference and manual toggle

### DIFF
--- a/components/organisms/Header/Header.tsx
+++ b/components/organisms/Header/Header.tsx
@@ -12,6 +12,7 @@ import { WalletModal } from '@/components/organisms/WalletModal/WalletModal';
 import { useWalletModal } from '@/components/organisms/WalletModal/useWalletModal';
 import { useWalletContext } from '@/contexts/WalletContext';
 import { useAppTranslation } from '@/hooks/useTranslation';
+import { useTheme } from '@/hooks/useTheme';
 import { cn } from '@/lib/utils';
 
 const NAV_LINKS = [
@@ -24,7 +25,7 @@ const NAV_LINKS = [
 export function Header(): JSX.Element {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
-  const [theme, setTheme] = useState<'light' | 'dark'>('dark');
+  const { theme, toggle: toggleTheme } = useTheme();
 
   const pathname = usePathname();
   const { wallet, disconnect } = useWalletContext();
@@ -37,11 +38,6 @@ export function Header(): JSX.Element {
     window.addEventListener('scroll', onScroll, { passive: true });
     return () => window.removeEventListener('scroll', onScroll);
   }, []);
-
-  // Theme toggle — applies .dark class to <html>
-  useEffect(() => {
-    document.documentElement.classList.toggle('dark', theme === 'dark');
-  }, [theme]);
 
   const handleWalletAction = (): void => {
     if (wallet?.publicKey) {
@@ -109,7 +105,7 @@ export function Header(): JSX.Element {
           <div className="hidden md:flex items-center gap-2">
             <button
               type="button"
-              onClick={() => setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'))}
+              onClick={toggleTheme}
               aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
               className="inline-flex h-9 w-9 items-center justify-center rounded-full text-white/70 transition-colors hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stellar-blue"
             >
@@ -160,7 +156,7 @@ export function Header(): JSX.Element {
           <div className="flex md:hidden items-center gap-2">
             <button
               type="button"
-              onClick={() => setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'))}
+              onClick={toggleTheme}
               aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
               className="inline-flex h-9 w-9 items-center justify-center rounded-full text-white/70 transition-colors hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stellar-blue"
             >

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -1,0 +1,29 @@
+'use client'
+import { useState, useEffect } from 'react'
+
+export function useTheme() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window === 'undefined') return 'dark'
+    const stored = localStorage.getItem('theme')
+    if (stored === 'light' || stored === 'dark') return stored
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  })
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark')
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme')
+    if (stored) return
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const handler = (e: MediaQueryListEvent) => setTheme(e.matches ? 'dark' : 'light')
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+
+  const toggle = () => setTheme(t => t === 'dark' ? 'light' : 'dark')
+
+  return { theme, toggle, isDark: theme === 'dark' }
+}


### PR DESCRIPTION
## Summary

- Adds `hooks/useTheme.ts` — a reusable hook that reads localStorage on init, falls back to `prefers-color-scheme`, persists manual selections, and listens for OS-level theme changes when no manual preference is set
- Updates `Header.tsx` to use `useTheme` in place of the previous hard-coded dark initializer, so the toggle button now correctly reflects and persists the user's preference across page loads
- No change to `app/layout.tsx` — the existing `<Script strategy="beforeInteractive">` inline script already handles flash-of-wrong-theme on first load; the hook and the script are consistent

## Test plan

- [ ] Open the app with no localStorage entry — should match OS dark/light preference
- [ ] Toggle the button — sun/moon icon flips, page switches theme, `localStorage.theme` is set
- [ ] Reload — theme is restored from localStorage without flash
- [ ] Clear localStorage, change OS dark/light preference — page updates in real time
- [ ] With a stored preference, change OS preference — stored value wins, no change

closes #534