### PR TITLE
feat(contract): planter availability toggle - planters can pause accepting jobs

### DIFF
--- a/contracts/farmer-registry/src/lib.rs
+++ b/contracts/farmer-registry/src/lib.rs
@@ -183,6 +183,47 @@ impl FarmerRegistry {
             .has(&Self::farmer_key(&env, &wallet_address))
     }
 
+
+    /// Toggle planter availability — planters can pause accepting new jobs
+    /// without being penalised or removed from the registry.
+    ///
+    /// # Parameters
+    /// - `wallet_address`: The planter's wallet (must match the caller).
+    /// - `available`: `true` to accept jobs, `false` to pause.
+    ///
+    /// # Errors
+    /// Panics with "farmer not registered" if the caller has no profile.
+    ///
+    /// # Events
+    /// Emits `(symbol_short!("AvailSet"), wallet_address)` with the new value.
+    pub fn set_available(env: Env, wallet_address: Address, available: bool) {
+        wallet_address.require_auth();
+
+        // Planter must be registered before toggling availability.
+        if !env.storage().persistent().has(&Self::farmer_key(&env, &wallet_address)) {
+            panic!("farmer not registered");
+        }
+
+        let key = Self::availability_key(&env, &wallet_address);
+        env.storage().persistent().set(&key, &available);
+
+        env.events().publish(
+            (symbol_short!("AvailSet"), wallet_address.clone()),
+            available,
+        );
+    }
+
+    /// Returns `true` if the planter is currently accepting jobs.
+    /// Defaults to `true` for registered planters who have never called
+    /// `set_available` — availability is opt-out, not opt-in.
+    pub fn is_available(env: Env, wallet_address: Address) -> bool {
+        let key = Self::availability_key(&env, &wallet_address);
+        env.storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(true)
+    }
+
     // ── internal ──────────────────────────────────────────────────────────────
 
     fn farmer_key(env: &Env, wallet: &Address) -> soroban_sdk::Val {
@@ -195,6 +236,10 @@ impl FarmerRegistry {
 
     fn history_key(env: &Env, wallet: &Address, version: u32) -> soroban_sdk::Val {
         (symbol_short!("HIST"), wallet.clone(), version).into_val(env)
+    }
+
+    fn availability_key(env: &Env, wallet: &Address) -> soroban_sdk::Val {
+        (symbol_short!("AVAIL"), wallet.clone()).into_val(env)
     }
 
     /// Northern Nigeria geohash validation (2-char prefixes)
@@ -398,4 +443,78 @@ mod tests {
 
         assert!(client.get_farmer(&stranger).is_none());
     }
+    // ── availability tests ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_default_availability_is_true() {
+        let (env, _, client) = setup();
+        let farmer = Address::generate(&env);
+
+        client.register_farmer(&farmer, &land_hash(&env, 1), &String::from_str(&env, "s1"));
+
+        // Planters are available by default — opt-out model.
+        assert!(client.is_available(&farmer));
+    }
+
+    #[test]
+    fn test_set_available_false_pauses_planter() {
+        let (env, _, client) = setup();
+        let farmer = Address::generate(&env);
+
+        client.register_farmer(&farmer, &land_hash(&env, 1), &String::from_str(&env, "s1"));
+        client.set_available(&farmer, &false);
+
+        assert!(!client.is_available(&farmer));
+    }
+
+    #[test]
+    fn test_set_available_true_resumes_planter() {
+        let (env, _, client) = setup();
+        let farmer = Address::generate(&env);
+
+        client.register_farmer(&farmer, &land_hash(&env, 1), &String::from_str(&env, "s1"));
+        client.set_available(&farmer, &false);
+        client.set_available(&farmer, &true);
+
+        assert!(client.is_available(&farmer));
+    }
+
+    #[test]
+    #[should_panic(expected = "farmer not registered")]
+    fn test_set_available_unregistered_panics() {
+        let (env, _, client) = setup();
+        let stranger = Address::generate(&env);
+
+        client.set_available(&stranger, &false);
+    }
+
+    #[test]
+    fn test_availability_toggle_does_not_affect_profile() {
+        let (env, _, client) = setup();
+        let farmer = Address::generate(&env);
+
+        client.register_farmer(&farmer, &land_hash(&env, 1), &String::from_str(&env, "s1"));
+        client.set_available(&farmer, &false);
+
+        // Profile must still be intact after toggling availability.
+        let profile = client.get_farmer(&farmer).unwrap();
+        assert_eq!(profile.wallet_address, farmer);
+    }
+
+    #[test]
+    fn test_multiple_planters_independent_availability() {
+        let (env, _, client) = setup();
+        let farmer_a = Address::generate(&env);
+        let farmer_b = Address::generate(&env);
+
+        client.register_farmer(&farmer_a, &land_hash(&env, 1), &String::from_str(&env, "s1"));
+        client.register_farmer(&farmer_b, &land_hash(&env, 2), &String::from_str(&env, "s2"));
+
+        client.set_available(&farmer_a, &false);
+
+        assert!(!client.is_available(&farmer_a));
+        assert!(client.is_available(&farmer_b));
+    }
+
+
 }


### PR DESCRIPTION
Closes #513

## What this PR does
Adds set_available(bool) and is_available() to the farmer-registry
contract so planters can pause accepting new jobs without being
penalised or removed from the registry.

## Changes
- Updated contracts/farmer-registry/src/lib.rs
  - Added set_available(env, wallet_address, available) — requires auth,
    panics if planter not registered, stores availability flag in
    persistent storage, emits AvailSet event
  - Added is_available(env, wallet_address) — returns true by default
    (opt-out model, not opt-in) for registered planters
  - Added availability_key() internal helper

## Design Decisions
- Opt-out model: planters are available by default, no migration needed
- Availability is stored independently of the profile — toggling does
  not affect the FarmerProfile struct or version history
- Each planter's availability is independent of others

## Tests Added
- test_default_availability_is_true
- test_set_available_false_pauses_planter
- test_set_available_true_resumes_planter
- test_set_available_unregistered_panics
- test_availability_toggle_does_not_affect_profile
- test_multiple_planters_independent_availability

## Acceptance Criteria
- [x] set_available(bool) implemented
- [x] Planters can pause without penalty (profile unchanged)
- [x] Auth required — only the planter can toggle their own availability
- [x] cargo check passes with zero errors