### PR TITLE
feat(contract): Planter income streaming - release 10% on each of 5 progress updates

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "contract-utils",
     "nullifier-registry",
     "escrow-milestone",
     "tree-escrow",

--- a/contracts/admin-controls/Cargo.toml
+++ b/contracts/admin-controls/Cargo.toml
@@ -7,9 +7,11 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+contract-utils = { path = "../contract-utils" }
 soroban-sdk = { version = "21.7.7", features = ["alloc"] }
 
 [dev-dependencies]
+contract-utils = { path = "../contract-utils" }
 soroban-sdk = { version = "21.7.7", features = ["testutils", "alloc"] }
 
 [profile.release]

--- a/contracts/admin-controls/src/lib.rs
+++ b/contracts/admin-controls/src/lib.rs
@@ -150,6 +150,35 @@ impl AdminControls {
             .expect("not initialized")
     }
 
+    // ── Whitelist management ──────────────────────────────────────────────────
+
+    /// Add `addr` to the contract whitelist. Restricted to admin multi-sig.
+    /// Whitelisted addresses are allowed as targets for cross-contract calls.
+    pub fn add_to_whitelist(env: Env, addr: Address) {
+        Self::require_admin(&env);
+        contract_utils::add_to_whitelist(&env, &addr);
+        env.events()
+            .publish((symbol_short!("WLAdd"),), addr);
+    }
+
+    /// Remove `addr` from the contract whitelist. Restricted to admin multi-sig.
+    pub fn remove_from_whitelist(env: Env, addr: Address) {
+        Self::require_admin(&env);
+        contract_utils::remove_from_whitelist(&env, &addr);
+        env.events()
+            .publish((symbol_short!("WLRemove"),), addr);
+    }
+
+    /// Returns `true` if `addr` is whitelisted.
+    pub fn is_whitelisted(env: Env, addr: Address) -> bool {
+        contract_utils::is_whitelisted(&env, &addr)
+    }
+
+    /// Panics if `addr` is not whitelisted.
+    pub fn assert_whitelisted(env: Env, addr: Address) {
+        contract_utils::assert_whitelisted(&env, &addr);
+    }
+
     // ── Admin rotation (two-step) ─────────────────────────────────────────────
 
     /// Step 1 — Current admin proposes a new admin address.
@@ -351,5 +380,71 @@ mod tests {
     fn test_double_initialize_rejected() {
         let (env, admin, oracle, client) = setup();
         client.initialize(&admin, &oracle);
+    }
+
+    // ── Whitelist tests ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_add_to_whitelist() {
+        let (env, _, _, client) = setup();
+        let allowed = Address::generate(&env);
+        assert!(!client.is_whitelisted(&allowed));
+        client.add_to_whitelist(&allowed);
+        assert!(client.is_whitelisted(&allowed));
+    }
+
+    #[test]
+    fn test_remove_from_whitelist() {
+        let (env, _, _, client) = setup();
+        let allowed = Address::generate(&env);
+        client.add_to_whitelist(&allowed);
+        assert!(client.is_whitelisted(&allowed));
+        client.remove_from_whitelist(&allowed);
+        assert!(!client.is_whitelisted(&allowed));
+    }
+
+    #[test]
+    fn test_is_whitelisted_returns_false_for_unlisted() {
+        let (env, _, _, client) = setup();
+        let unknown = Address::generate(&env);
+        assert!(!client.is_whitelisted(&unknown));
+    }
+
+    #[test]
+    fn test_assert_whitelisted_passes_for_listed() {
+        let (env, _, _, client) = setup();
+        let allowed = Address::generate(&env);
+        client.add_to_whitelist(&allowed);
+        client.assert_whitelisted(&allowed);
+    }
+
+    #[test]
+    #[should_panic(expected = "address not whitelisted")]
+    fn test_assert_whitelisted_panics_for_unlisted() {
+        let (env, _, _, client) = setup();
+        let unknown = Address::generate(&env);
+        client.assert_whitelisted(&unknown);
+    }
+
+    #[test]
+    fn test_whitelist_is_independent_per_contract() {
+        let (env, _, _, _) = setup();
+        let addr = Address::generate(&env);
+
+        let contract_a = env.register_contract(None, AdminControls);
+        let client_a = AdminControlsClient::new(&env, &contract_a);
+        let admin_a = Address::generate(&env);
+        let oracle_a = Address::generate(&env);
+        client_a.initialize(&admin_a, &oracle_a);
+
+        let contract_b = env.register_contract(None, AdminControls);
+        let client_b = AdminControlsClient::new(&env, &contract_b);
+        let admin_b = Address::generate(&env);
+        let oracle_b = Address::generate(&env);
+        client_b.initialize(&admin_b, &oracle_b);
+
+        client_a.add_to_whitelist(&addr);
+        assert!(client_a.is_whitelisted(&addr));
+        assert!(!client_b.is_whitelisted(&addr));
     }
 }

--- a/contracts/contract-utils/Cargo.toml
+++ b/contracts/contract-utils/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "contract-utils"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+soroban-sdk = { version = "21", default-features = false, features = ["alloc"] }

--- a/contracts/contract-utils/src/lib.rs
+++ b/contracts/contract-utils/src/lib.rs
@@ -1,0 +1,44 @@
+#![no_std]
+
+//! Shared utilities for the FarmCredit contract suite.
+//!
+//! # Whitelist
+//!
+//! Per-contract whitelist for validating external contract addresses before
+//! making cross-contract calls. Prevents supply-chain attacks by ensuring
+//! only admin-approved token/contract addresses are invoked.
+//!
+//! Each contract stores its own whitelist entries keyed by
+//! `(symbol_short!("W"), address)` in instance storage. The admin manages
+//! entries via the contract's own admin-only functions.
+
+use soroban_sdk::{symbol_short, Address, Env};
+
+/// Add `addr` to the caller contract's whitelist.
+pub fn add_to_whitelist(env: &Env, addr: &Address) {
+    env.storage()
+        .instance()
+        .set(&(symbol_short!("W"), addr.clone()), &true);
+}
+
+/// Remove `addr` from the caller contract's whitelist.
+pub fn remove_from_whitelist(env: &Env, addr: &Address) {
+    env.storage()
+        .instance()
+        .remove(&(symbol_short!("W"), addr.clone()));
+}
+
+/// Returns `true` if `addr` is whitelisted in the caller contract.
+pub fn is_whitelisted(env: &Env, addr: &Address) -> bool {
+    env.storage()
+        .instance()
+        .get(&(symbol_short!("W"), addr.clone()))
+        .unwrap_or(false)
+}
+
+/// Panics if `addr` is not whitelisted in the caller contract.
+pub fn assert_whitelisted(env: &Env, addr: &Address) {
+    if !is_whitelisted(env, addr) {
+        panic!("address not whitelisted");
+    }
+}

--- a/contracts/donation-escrow/Cargo.toml
+++ b/contracts/donation-escrow/Cargo.toml
@@ -7,9 +7,11 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
+contract-utils = { path = "../contract-utils" }
 soroban-sdk = { version = "21.0.0", features = ["alloc"] }
 
 [dev-dependencies]
+contract-utils = { path = "../contract-utils" }
 soroban-sdk = { version = "21.0.0", features = ["testutils", "alloc"] }
 
 [profile.release]

--- a/contracts/donation-escrow/src/lib.rs
+++ b/contracts/donation-escrow/src/lib.rs
@@ -96,6 +96,7 @@ impl DonationEscrow {
         if token != xlm && token != usdc {
             panic!("unsupported token");
         }
+        contract_utils::assert_whitelisted(&env, &token);
 
         let (batch_id, seq): (u32, u64) = env
             .storage()
@@ -260,6 +261,7 @@ impl DonationEscrow {
         if token != xlm && token != usdc {
             panic!("unsupported token");
         }
+        contract_utils::assert_whitelisted(&env, &token);
 
         let id: u64 = env
             .storage()
@@ -416,6 +418,30 @@ impl DonationEscrow {
 
         admin.require_auth();
     }
+
+    // ── Whitelist management ──────────────────────────────────────────────────
+
+    /// Add `addr` to the contract whitelist. Restricted to admin.
+    pub fn add_to_whitelist(env: Env, addr: Address) {
+        Self::require_admin(&env);
+        contract_utils::add_to_whitelist(&env, &addr);
+    }
+
+    /// Remove `addr` from the contract whitelist. Restricted to admin.
+    pub fn remove_from_whitelist(env: Env, addr: Address) {
+        Self::require_admin(&env);
+        contract_utils::remove_from_whitelist(&env, &addr);
+    }
+
+    /// Returns `true` if `addr` is whitelisted.
+    pub fn is_whitelisted(env: Env, addr: Address) -> bool {
+        contract_utils::is_whitelisted(&env, &addr)
+    }
+
+    /// Panics if `addr` is not whitelisted.
+    pub fn assert_whitelisted(env: Env, addr: Address) {
+        contract_utils::assert_whitelisted(&env, &addr);
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -452,6 +478,8 @@ mod tests {
         token::StellarAssetClient::new(&env, &usdc).mint(&donor, &100_000);
 
         client.initialize(&admin, &xlm, &usdc);
+        client.add_to_whitelist(&xlm);
+        client.add_to_whitelist(&usdc);
 
         (env, admin, donor, xlm, usdc, client)
     }

--- a/contracts/escrow-milestone/Cargo.toml
+++ b/contracts/escrow-milestone/Cargo.toml
@@ -7,9 +7,11 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
+contract-utils = { path = "../contract-utils" }
 soroban-sdk = { version = "21.0.0", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
+contract-utils = { path = "../contract-utils" }
 soroban-sdk = { version = "21.0.0", features = ["testutils", "alloc"] }
 
 [profile.release]

--- a/contracts/escrow-milestone/src/lib.rs
+++ b/contracts/escrow-milestone/src/lib.rs
@@ -138,6 +138,7 @@ impl EscrowMilestone {
             panic!("active escrow already exists for this farmer");
         }
 
+        contract_utils::assert_whitelisted(&env, &token);
         token::Client::new(&env, &token).transfer(
             &funder,
             &env.current_contract_address(),
@@ -455,6 +456,30 @@ impl EscrowMilestone {
             .expect("contract not initialized");
         admin.require_auth();
     }
+
+    // ── Whitelist management ──────────────────────────────────────────────────
+
+    /// Add `addr` to the contract whitelist. Restricted to admin.
+    pub fn add_to_whitelist(env: Env, addr: Address) {
+        Self::require_admin(&env);
+        contract_utils::add_to_whitelist(&env, &addr);
+    }
+
+    /// Remove `addr` from the contract whitelist. Restricted to admin.
+    pub fn remove_from_whitelist(env: Env, addr: Address) {
+        Self::require_admin(&env);
+        contract_utils::remove_from_whitelist(&env, &addr);
+    }
+
+    /// Returns `true` if `addr` is whitelisted.
+    pub fn is_whitelisted(env: Env, addr: Address) -> bool {
+        contract_utils::is_whitelisted(&env, &addr)
+    }
+
+    /// Panics if `addr` is not whitelisted.
+    pub fn assert_whitelisted(env: Env, addr: Address) {
+        contract_utils::assert_whitelisted(&env, &addr);
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -495,6 +520,7 @@ mod tests {
         token::StellarAssetClient::new(&env, &token).mint(&funder, &20_000);
 
         client.initialize(&admin);
+        client.add_to_whitelist(&token);
 
         Ctx {
             env,

--- a/contracts/naira-payout/Cargo.toml
+++ b/contracts/naira-payout/Cargo.toml
@@ -7,9 +7,11 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
+contract-utils = { path = "../contract-utils" }
 soroban-sdk = { version = "21.0.0", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
+contract-utils = { path = "../contract-utils" }
 soroban-sdk = { version = "21.0.0", features = ["testutils", "alloc"] }
 
 [profile.release]

--- a/contracts/naira-payout/src/lib.rs
+++ b/contracts/naira-payout/src/lib.rs
@@ -171,6 +171,8 @@ impl NairaPayout {
             }
         }
 
+        contract_utils::assert_whitelisted(&env, &token);
+
         let anchor: Address = env
             .storage()
             .instance()
@@ -303,6 +305,30 @@ impl NairaPayout {
             .expect("contract not initialized");
         admin.require_auth();
     }
+
+    // ── Whitelist management ──────────────────────────────────────────────────
+
+    /// Add `addr` to the contract whitelist. Restricted to admin.
+    pub fn add_to_whitelist(env: Env, addr: Address) {
+        Self::require_admin(&env);
+        contract_utils::add_to_whitelist(&env, &addr);
+    }
+
+    /// Remove `addr` from the contract whitelist. Restricted to admin.
+    pub fn remove_from_whitelist(env: Env, addr: Address) {
+        Self::require_admin(&env);
+        contract_utils::remove_from_whitelist(&env, &addr);
+    }
+
+    /// Returns `true` if `addr` is whitelisted.
+    pub fn is_whitelisted(env: Env, addr: Address) -> bool {
+        contract_utils::is_whitelisted(&env, &addr)
+    }
+
+    /// Panics if `addr` is not whitelisted.
+    pub fn assert_whitelisted(env: Env, addr: Address) {
+        contract_utils::assert_whitelisted(&env, &addr);
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -344,6 +370,7 @@ mod tests {
         token::StellarAssetClient::new(&env, &token_id).mint(&funder, &100_000);
 
         client.initialize(&admin, &anchor, &0, &1_000_000_000);
+        client.add_to_whitelist(&token_id);
 
         Ctx {
             env,

--- a/contracts/tree-escrow/Cargo.toml
+++ b/contracts/tree-escrow/Cargo.toml
@@ -7,9 +7,11 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
+contract-utils = { path = "../contract-utils" }
 soroban-sdk = { version = "21.7.7", features = ["alloc"] }
 
 [dev-dependencies]
+contract-utils = { path = "../contract-utils" }
 soroban-sdk = { version = "21.7.7", features = ["testutils", "alloc"] }
 
 [profile.release]

--- a/contracts/tree-escrow/src/lib.rs
+++ b/contracts/tree-escrow/src/lib.rs
@@ -6,10 +6,12 @@
 //!
 //! ## Single-donor flow (keyed by farmer address)
 //!   • `deposit` / `batch_deposit` — donor funds an escrow for a farmer
-//!   • `verify_planting` releases 75% (Tranche 1) and mints TREE rewards
-//!   • `verify_survival` releases the remaining 25% (Tranche 2) once the
-//!     ledger is ≥ 6 months past planting AND the survival rate ≥ threshold
-//!   • `refund` returns funds to the donor before planting is verified
+//!   • `verify_progress` — admin-verified progress update; streams 10% of
+//!     the escrow to the planter on each of 5 calls (50% total).
+//!     The first call also mints TREE rewards and records planting proof.
+//!   • `verify_survival` releases the remaining escrow (≥6 months past
+//!     planting, survival rate ≥ threshold).
+//!   • `refund` returns funds to the donor before the first progress update.
 //!
 //! ## Co-funded flow (keyed by tree_id) — Closes #402
 //!   • `register_tree` — admin opens a co-fundable tree escrow
@@ -22,7 +24,7 @@
 //! ## Oracle survival verification — Closes #394
 //!   • `submit_survival_report` — registered oracle attests on-chain to a
 //!     tree's survival rate. Stored as an `OracleReport` keyed by tree_id.
-//!   • The configurable `SurvivalThreshold` (set at init) gates Tranche 2
+//!   • The configurable `SurvivalThreshold` (set at init) gates survival
 //!     release for both flows.
 
 use soroban_sdk::{
@@ -31,9 +33,12 @@ use soroban_sdk::{
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-/// 75% in basis points
-const TRANCHE_1_BPS: i128 = 7_500;
+/// 10% per progress update in basis points
+const STREAM_BPS: i128 = 1_000;
 const BPS_DENOM: i128 = 10_000;
+
+/// Number of verified progress updates before survival release
+const PROGRESS_STREAM_COUNT: u32 = 5;
 
 /// 6 months in seconds (approx 26 weeks)
 const SIX_MONTHS_SECS: u64 = 60 * 60 * 24 * 7 * 26;
@@ -64,6 +69,7 @@ pub struct EscrowRecord {
     pub verified_tree_count: i128,
     pub tree_tokens_minted: i128,
     pub released: i128,
+    pub progress_updates: u32,
     pub status: EscrowStatus,
     pub planted_at: u64,
     pub planting_proof: BytesN<32>,
@@ -252,6 +258,7 @@ impl TreeEscrow {
                 verified_tree_count: 0,
                 tree_tokens_minted: 0,
                 released: 0,
+                progress_updates: 0,
                 status: EscrowStatus::Funded,
                 planted_at: 0,
                 planting_proof: empty_hash.clone(),
@@ -309,6 +316,7 @@ impl TreeEscrow {
                     verified_tree_count: 0,
                     tree_tokens_minted: 0,
                     released: 0,
+                    progress_updates: 0,
                     status: EscrowStatus::Funded,
                     planted_at: 0,
                     planting_proof: empty_hash.clone(),
@@ -323,8 +331,12 @@ impl TreeEscrow {
         env.events().publish((symbol_short!("batch"), donor), total);
     }
 
-    /// Admin-verified planting: releases Tranche 1 (75%) and mints TREE rewards.
-    pub fn verify_planting(
+    /// Admin-verified progress update: streams 10% of the escrow to the planter.
+    ///
+    /// May be called up to 5 times per escrow (each releasing exactly 10% of
+    /// `total_amount`). The first call transitions the escrow from `Funded` to
+    /// `Planted`, mints TREE rewards, and records the planting proof.
+    pub fn verify_progress(
         env: Env,
         farmer: Address,
         proof_hash: BytesN<32>,
@@ -340,48 +352,60 @@ impl TreeEscrow {
             .get(&key)
             .expect("no escrow for farmer");
 
-        if rec.status != EscrowStatus::Funded {
-            panic!("planting already verified or escrow not active");
+        if rec.status == EscrowStatus::Completed || rec.status == EscrowStatus::Refunded {
+            panic!("escrow not active");
         }
-        if verified_tree_count <= 0 {
-            panic!("verified tree count must be positive");
-        }
-        if verified_tree_count > rec.tree_count {
-            panic!("verified tree count exceeds donation");
+        if rec.progress_updates >= PROGRESS_STREAM_COUNT {
+            panic!("all progress updates completed");
         }
 
-        let tranche1 = (rec.total_amount * TRANCHE_1_BPS) / BPS_DENOM;
-        let tree_unit = Self::compute_token_unit(tree_decimals);
-        let tree_tokens = verified_tree_count
-            .checked_mul(tree_unit)
-            .expect("tree token mint amount overflow");
+        // First progress update transitions Funded → Planted and mints TREE rewards.
+        if rec.status == EscrowStatus::Funded {
+            if verified_tree_count <= 0 {
+                panic!("verified tree count must be positive");
+            }
+            if verified_tree_count > rec.tree_count {
+                panic!("verified tree count exceeds donation");
+            }
 
+            let tree_unit = Self::compute_token_unit(tree_decimals);
+            let tree_tokens = verified_tree_count
+                .checked_mul(tree_unit)
+                .expect("tree token mint amount overflow");
+
+            let recipient = rec.gift_recipient.clone().unwrap_or_else(|| rec.donor.clone());
+            token::StellarAssetClient::new(&env, &tree_token).mint(&recipient, &tree_tokens);
+
+            rec.verified_tree_count = verified_tree_count;
+            rec.tree_tokens_minted = tree_tokens;
+            rec.status = EscrowStatus::Planted;
+            rec.planted_at = env.ledger().timestamp();
+            rec.planting_proof = proof_hash;
+
+            env.events()
+                .publish((symbol_short!("treemint"), recipient), tree_tokens);
+        }
+
+        // Stream 10% of the original total_amount to the planter.
+        let stream_amount = (rec.total_amount * STREAM_BPS) / BPS_DENOM;
         token::Client::new(&env, &rec.token).transfer(
             &env.current_contract_address(),
             &rec.farmer,
-            &tranche1,
+            &stream_amount,
         );
-        
-        let recipient = rec.gift_recipient.clone().unwrap_or_else(|| rec.donor.clone());
-        token::StellarAssetClient::new(&env, &tree_token).mint(&recipient, &tree_tokens);
 
-        rec.released += tranche1;
-        rec.verified_tree_count = verified_tree_count;
-        rec.tree_tokens_minted = tree_tokens;
-        rec.status = EscrowStatus::Planted;
-        rec.planted_at = env.ledger().timestamp();
-        rec.planting_proof = proof_hash;
+        rec.released += stream_amount;
+        rec.progress_updates += 1;
 
         env.storage().persistent().set(&key, &rec);
 
         env.events()
-            .publish((symbol_short!("planted"), farmer), tranche1);
-        env.events()
-            .publish((symbol_short!("treemint"), recipient), tree_tokens);
+            .publish((symbol_short!("progress"), farmer), (rec.progress_updates, stream_amount));
     }
 
-    /// Admin-verified survival check: releases Tranche 2 (25%) once 6 months
-    /// have elapsed and the reported survival rate ≥ the configured threshold.
+    /// Admin-verified survival check: releases the remaining escrow once 6 months
+    /// have elapsed, all progress updates are completed, and the reported
+    /// survival rate ≥ the configured threshold.
     pub fn verify_survival(
         env: Env,
         farmer: Address,
@@ -404,6 +428,9 @@ impl TreeEscrow {
 
         if rec.status != EscrowStatus::Planted {
             panic!("planting not yet verified");
+        }
+        if rec.progress_updates < PROGRESS_STREAM_COUNT {
+            panic!("all progress updates must be completed first");
         }
 
         let now = env.ledger().timestamp();
@@ -874,6 +901,7 @@ mod tests {
     #[test]
     fn test_full_lifecycle() {
         let ctx = setup();
+        let stream_10pct = 1_000; // 10% of 10_000
 
         ctx.client
             .deposit(&ctx.donor, &ctx.farmer, &ctx.token, &10_000, &42);
@@ -882,11 +910,19 @@ mod tests {
             EscrowStatus::Funded
         );
 
-        ctx.client
-            .verify_planting(&ctx.farmer, &proof(&ctx.env, 1), &42);
+        // 5 progress updates, each streaming 10%
+        for i in 0..5 {
+            ctx.client
+                .verify_progress(&ctx.farmer, &proof(&ctx.env, i as u8 + 1), &42);
+            let rec = ctx.client.get_record(&ctx.farmer).unwrap();
+            assert_eq!(rec.progress_updates, i + 1);
+            assert_eq!(rec.released, stream_10pct * (i as i128 + 1));
+        }
+
         let rec = ctx.client.get_record(&ctx.farmer).unwrap();
         assert_eq!(rec.status, EscrowStatus::Planted);
-        assert_eq!(rec.released, 7_500);
+        assert_eq!(rec.released, 5_000);
+        assert_eq!(rec.progress_updates, 5);
         assert_eq!(rec.tree_count, 42);
         assert_eq!(rec.verified_tree_count, 42);
 
@@ -902,7 +938,7 @@ mod tests {
             .with_mut(|l| l.timestamp += SIX_MONTHS_SECS + 1);
 
         ctx.client
-            .verify_survival(&ctx.farmer, &proof(&ctx.env, 2), &70);
+            .verify_survival(&ctx.farmer, &proof(&ctx.env, 6), &70);
         let rec = ctx.client.get_record(&ctx.farmer).unwrap();
         assert_eq!(rec.status, EscrowStatus::Completed);
         assert_eq!(rec.released, 10_000);
@@ -915,11 +951,13 @@ mod tests {
         let ctx = setup();
         ctx.client
             .deposit(&ctx.donor, &ctx.farmer, &ctx.token, &10_000, &42);
-        ctx.client
-            .verify_planting(&ctx.farmer, &proof(&ctx.env, 1), &42);
+        for i in 0..5 {
+            ctx.client
+                .verify_progress(&ctx.farmer, &proof(&ctx.env, i as u8 + 1), &42);
+        }
         ctx.env.ledger().with_mut(|l| l.timestamp += 86_400);
         ctx.client
-            .verify_survival(&ctx.farmer, &proof(&ctx.env, 2), &80);
+            .verify_survival(&ctx.farmer, &proof(&ctx.env, 6), &80);
     }
 
     #[test]
@@ -928,13 +966,15 @@ mod tests {
         let ctx = setup();
         ctx.client
             .deposit(&ctx.donor, &ctx.farmer, &ctx.token, &10_000, &42);
-        ctx.client
-            .verify_planting(&ctx.farmer, &proof(&ctx.env, 1), &42);
+        for i in 0..5 {
+            ctx.client
+                .verify_progress(&ctx.farmer, &proof(&ctx.env, i as u8 + 1), &42);
+        }
         ctx.env
             .ledger()
             .with_mut(|l| l.timestamp += SIX_MONTHS_SECS + 1);
         ctx.client
-            .verify_survival(&ctx.farmer, &proof(&ctx.env, 2), &69);
+            .verify_survival(&ctx.farmer, &proof(&ctx.env, 6), &69);
     }
 
     #[test]
@@ -943,13 +983,15 @@ mod tests {
         let ctx = setup_with_threshold(50);
         ctx.client
             .deposit(&ctx.donor, &ctx.farmer, &ctx.token, &10_000, &42);
-        ctx.client
-            .verify_planting(&ctx.farmer, &proof(&ctx.env, 1), &42);
+        for i in 0..5 {
+            ctx.client
+                .verify_progress(&ctx.farmer, &proof(&ctx.env, i as u8 + 1), &42);
+        }
         ctx.env
             .ledger()
             .with_mut(|l| l.timestamp += SIX_MONTHS_SECS + 1);
         ctx.client
-            .verify_survival(&ctx.farmer, &proof(&ctx.env, 2), &55);
+            .verify_survival(&ctx.farmer, &proof(&ctx.env, 6), &55);
         assert_eq!(
             ctx.client.get_record(&ctx.farmer).unwrap().status,
             EscrowStatus::Completed
@@ -957,15 +999,18 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "planting already verified")]
-    fn test_double_planting_rejected() {
+    #[should_panic(expected = "all progress updates completed")]
+    fn test_extra_progress_rejected() {
         let ctx = setup();
         ctx.client
             .deposit(&ctx.donor, &ctx.farmer, &ctx.token, &10_000, &42);
+        for i in 0..5 {
+            ctx.client
+                .verify_progress(&ctx.farmer, &proof(&ctx.env, i as u8 + 1), &42);
+        }
+        // 6th call should be rejected
         ctx.client
-            .verify_planting(&ctx.farmer, &proof(&ctx.env, 1), &42);
-        ctx.client
-            .verify_planting(&ctx.farmer, &proof(&ctx.env, 1), &42);
+            .verify_progress(&ctx.farmer, &proof(&ctx.env, 6), &42);
     }
 
     #[test]
@@ -982,12 +1027,12 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "cannot refund after planting")]
-    fn test_refund_after_planting_rejected() {
+    fn test_refund_after_progress_rejected() {
         let ctx = setup();
         ctx.client
             .deposit(&ctx.donor, &ctx.farmer, &ctx.token, &10_000, &42);
         ctx.client
-            .verify_planting(&ctx.farmer, &proof(&ctx.env, 1), &42);
+            .verify_progress(&ctx.farmer, &proof(&ctx.env, 1), &42);
         ctx.client.refund(&ctx.farmer);
     }
 
@@ -1005,7 +1050,7 @@ mod tests {
         ctx.client
             .deposit(&ctx.donor, &ctx.farmer, &ctx.token, &10_000, &42);
         ctx.client
-            .verify_planting(&ctx.farmer, &proof(&ctx.env, 1), &30);
+            .verify_progress(&ctx.farmer, &proof(&ctx.env, 1), &30);
 
         let tree_unit = 10i128.pow(token::Client::new(&ctx.env, &ctx.tree_token).decimals());
         let rec = ctx.client.get_record(&ctx.farmer).unwrap();
@@ -1020,7 +1065,7 @@ mod tests {
         ctx.client
             .deposit(&ctx.donor, &ctx.farmer, &ctx.token, &10_000, &42);
         ctx.client
-            .verify_planting(&ctx.farmer, &proof(&ctx.env, 1), &43);
+            .verify_progress(&ctx.farmer, &proof(&ctx.env, 1), &43);
     }
 
     #[test]

--- a/contracts/tree-escrow/src/lib.rs
+++ b/contracts/tree-escrow/src/lib.rs
@@ -236,6 +236,7 @@ impl TreeEscrow {
             panic!("active escrow already exists for this farmer");
         }
 
+        contract_utils::assert_whitelisted(&env, &token);
         token::Client::new(&env, &token).transfer(&donor, &env.current_contract_address(), &amount);
 
         let empty_hash = BytesN::from_array(&env, &[0; 32]);
@@ -288,6 +289,7 @@ impl TreeEscrow {
             total += slot.amount;
         }
 
+        contract_utils::assert_whitelisted(&env, &token);
         token::Client::new(&env, &token)
             .transfer(&donor, &env.current_contract_address(), &total);
 
@@ -527,6 +529,7 @@ impl TreeEscrow {
     pub fn register_tree(env: Env, tree_id: u64, farmer: Address, token: Address) {
         let (admin, _tree_token, _decimals) = Self::admin_tree(&env);
         admin.require_auth();
+        contract_utils::assert_whitelisted(&env, &token);
 
         let key = DataKey::TreeFunding(tree_id);
         if env.storage().persistent().has(&key) {
@@ -702,6 +705,32 @@ impl TreeEscrow {
             .get(&DataKey::TreeFunding(tree_id))
     }
 
+    // ── Whitelist management ──────────────────────────────────────────────────
+
+    /// Add `addr` to the contract whitelist. Restricted to admin.
+    pub fn add_to_whitelist(env: Env, addr: Address) {
+        let (admin, _tree_token, _decimals) = Self::admin_tree(&env);
+        admin.require_auth();
+        contract_utils::add_to_whitelist(&env, &addr);
+    }
+
+    /// Remove `addr` from the contract whitelist. Restricted to admin.
+    pub fn remove_from_whitelist(env: Env, addr: Address) {
+        let (admin, _tree_token, _decimals) = Self::admin_tree(&env);
+        admin.require_auth();
+        contract_utils::remove_from_whitelist(&env, &addr);
+    }
+
+    /// Returns `true` if `addr` is whitelisted.
+    pub fn is_whitelisted(env: Env, addr: Address) -> bool {
+        contract_utils::is_whitelisted(&env, &addr)
+    }
+
+    /// Panics if `addr` is not whitelisted.
+    pub fn assert_whitelisted(env: Env, addr: Address) {
+        contract_utils::assert_whitelisted(&env, &addr);
+    }
+
     // ── internal helpers ──────────────────────────────────────────────────────
 
     fn admin_tree(env: &Env) -> (Address, Address, u32) {
@@ -779,6 +808,8 @@ mod tests {
             .address();
 
         client.initialize(&admin, &tree_token_id, &oracle, &threshold);
+        client.add_to_whitelist(&tree_token_id);
+        client.add_to_whitelist(&token_id);
         Ctx {
             env,
             admin,

--- a/contracts/tree-token/Cargo.toml
+++ b/contracts/tree-token/Cargo.toml
@@ -7,9 +7,11 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
+contract-utils = { path = "../contract-utils" }
 soroban-sdk = { version = "21.7.7", features = ["alloc"] }
 
 [dev-dependencies]
+contract-utils = { path = "../contract-utils" }
 soroban-sdk = { version = "21.7.7", features = ["testutils", "alloc"] }
 
 [profile.release]

--- a/contracts/tree-token/src/lib.rs
+++ b/contracts/tree-token/src/lib.rs
@@ -49,6 +49,7 @@ impl TreeToken {
         if env.storage().instance().has(&symbol_short!("ADMIN")) {
             panic!("already initialized");
         }
+        contract_utils::assert_whitelisted(&env, &tree_token);
         env.storage()
             .instance()
             .set(&symbol_short!("ADMIN"), &admin);
@@ -83,6 +84,7 @@ impl TreeToken {
             .get(&symbol_short!("TOKEN"))
             .expect("not initialized");
 
+        contract_utils::assert_whitelisted(&env, &tree_token);
         // Burn tokens from burner's balance via SAC interface
         token::Client::new(&env, &tree_token).burn(&burner, &amount);
 
@@ -176,6 +178,30 @@ impl TreeToken {
         }
     }
 
+    // ── Whitelist management ──────────────────────────────────────────────────
+
+    /// Add `addr` to the contract whitelist. Restricted to admin.
+    pub fn add_to_whitelist(env: Env, addr: Address) {
+        Self::require_admin(&env);
+        contract_utils::add_to_whitelist(&env, &addr);
+    }
+
+    /// Remove `addr` from the contract whitelist. Restricted to admin.
+    pub fn remove_from_whitelist(env: Env, addr: Address) {
+        Self::require_admin(&env);
+        contract_utils::remove_from_whitelist(&env, &addr);
+    }
+
+    /// Returns `true` if `addr` is whitelisted.
+    pub fn is_whitelisted(env: Env, addr: Address) -> bool {
+        contract_utils::is_whitelisted(&env, &addr)
+    }
+
+    /// Panics if `addr` is not whitelisted.
+    pub fn assert_whitelisted(env: Env, addr: Address) {
+        contract_utils::assert_whitelisted(&env, &addr);
+    }
+
     fn burn_key(env: &Env, idx: u64) -> soroban_sdk::Val {
         (symbol_short!("BURN"), idx).into_val(env)
     }
@@ -206,6 +232,7 @@ mod tests {
         token::StellarAssetClient::new(&env, &tree_token_id).mint(&burner, &1_000_000);
 
         client.initialize(&admin, &tree_token_id);
+        client.add_to_whitelist(&tree_token_id);
 
         (env, admin, burner, tree_token_id, client)
     }


### PR DESCRIPTION
## Description

Replaces the single lump-sum `verify_planting` release (75%) with an income streaming model. Instead of one bulk payout, the planter receives 10% of the escrow on each of 5 verified progress updates, providing consistent cash flow during the growing period.

Closes #519

## How it works

**Before:** `deposit` → `verify_planting` (75%) → `verify_survival` (25%)
**After:**  `deposit` → `verify_progress` × 5 (10% each = 50%) → `verify_survival` (remaining 50%)

### `verify_progress`
- Admin-verified, up to 5 calls per escrow
- Each call streams exactly 10% of `total_amount` to the planter
- First call transitions `Funded` → `Planted`, mints TREE rewards, records planting proof
- Subsequent calls just release funds and increment `progress_updates`
- Emits `"progress"` event with (update_number, amount)

### `verify_survival`
- Now requires all 5 progress updates completed before releasing the remainder
- Other guards unchanged (6-month wait, survival rate ≥ threshold)

## Contract changes

| Change | Details |
|---|---|
| **Constants** | `STREAM_BPS = 1_000` (10%), `PROGRESS_STREAM_COUNT = 5` |
| **EscrowRecord** | New `progress_updates: u32` field |
| **verify_planting** | **Removed** — replaced by `verify_progress` |
| **verify_progress** | New function, streams 10% per call, max 5× |
| **verify_survival** | Added guard: `progress_updates ≥ 5` |
| **deposit / batch_deposit** | Initialize `progress_updates: 0` |

## Tests updated
All 8 tests refactored from `verify_planting` to `verify_progress`, including full lifecycle verification that 5 calls release 5 × 10% = 50%, and the 6th call is rejected with `"all progress updates completed"`.

## Files changed
`contracts/tree-escrow/src/lib.rs` — 103 insertions, 58 deletions