### PR TITLE
feat(contracts): 2-of-3 multisig treasury for platform fee withdrawals

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -21,14 +21,26 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "admin-controls"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 21.7.7",
 ]
 
 [[package]]
 name = "aggregate-impact-verifier"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 21.7.7",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -47,6 +59,124 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
+dependencies = [
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+ "itertools 0.10.5",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "digest",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
+dependencies = [
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "derivative",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std",
+ "digest",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -124,7 +254,7 @@ dependencies = [
  "num-bigint",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -216,7 +346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -243,7 +373,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -277,7 +407,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -290,7 +420,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -301,7 +431,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -312,8 +442,14 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -336,6 +472,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,7 +490,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -362,7 +509,7 @@ dependencies = [
 name = "donation-escrow"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 21.7.7",
 ]
 
 [[package]]
@@ -455,7 +602,7 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 name = "escrow-milestone"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 21.7.7",
 ]
 
 [[package]]
@@ -468,7 +615,7 @@ checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 name = "farmer-registry"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 21.7.7",
 ]
 
 [[package]]
@@ -545,6 +692,15 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -637,6 +793,15 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
@@ -685,7 +850,7 @@ dependencies = [
 name = "kyc-attestation"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 21.7.7",
 ]
 
 [[package]]
@@ -704,7 +869,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 name = "location-proof"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 21.7.7",
 ]
 
 [[package]]
@@ -732,14 +897,14 @@ dependencies = [
 name = "naira-payout"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 21.7.7",
 ]
 
 [[package]]
 name = "nullifier-registry"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 21.7.7",
 ]
 
 [[package]]
@@ -766,7 +931,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -852,7 +1017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -929,7 +1094,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1033,7 +1198,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1077,7 +1242,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1129,10 +1294,22 @@ version = "21.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f57a68ef8777e28e274de0f3a88ad9a5a41d9a2eb461b4dd800b086f0e83b80"
 dependencies = [
- "itertools",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "soroban-builtin-sdk-macros"
+version = "22.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2e42bf80fcdefb3aae6ff3c7101a62cf942e95320ed5b518a1705bc11c6b2f"
+dependencies = [
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1147,10 +1324,29 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
- "soroban-env-macros",
+ "soroban-env-macros 21.2.1",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr",
+ "stellar-xdr 21.2.0",
+ "wasmparser",
+]
+
+[[package]]
+name = "soroban-env-common"
+version = "22.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "027cd856171bfd6ad2c0ffb3b7dfe55ad7080fb3050c36ad20970f80da634472"
+dependencies = [
+ "arbitrary",
+ "crate-git-revision",
+ "ethnum",
+ "num-derive",
+ "num-traits",
+ "serde",
+ "soroban-env-macros 22.1.3",
+ "soroban-wasmi",
+ "static_assertions",
+ "stellar-xdr 22.1.0",
  "wasmparser",
 ]
 
@@ -1160,7 +1356,17 @@ version = "21.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bfb2536811045d5cd0c656a324cbe9ce4467eb734c7946b74410d90dea5d0ce"
 dependencies = [
- "soroban-env-common",
+ "soroban-env-common 21.2.1",
+ "static_assertions",
+]
+
+[[package]]
+name = "soroban-env-guest"
+version = "22.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a07dda1ae5220d975979b19ad4fd56bc86ec7ec1b4b25bc1c5d403f934e592e"
+dependencies = [
+ "soroban-env-common 22.1.3",
  "static_assertions",
 ]
 
@@ -1189,11 +1395,47 @@ dependencies = [
  "sec1",
  "sha2",
  "sha3",
- "soroban-builtin-sdk-macros",
- "soroban-env-common",
+ "soroban-builtin-sdk-macros 21.2.1",
+ "soroban-env-common 21.2.1",
  "soroban-wasmi",
  "static_assertions",
- "stellar-strkey",
+ "stellar-strkey 0.0.8",
+ "wasmparser",
+]
+
+[[package]]
+name = "soroban-env-host"
+version = "22.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e8b03a4191d485eab03f066336112b2a50541a7553179553dc838b986b94dd"
+dependencies = [
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "curve25519-dalek",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "generic-array",
+ "getrandom",
+ "hex-literal",
+ "hmac",
+ "k256",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "p256",
+ "rand",
+ "rand_chacha",
+ "sec1",
+ "sha2",
+ "sha3",
+ "soroban-builtin-sdk-macros 22.1.3",
+ "soroban-env-common 22.1.3",
+ "soroban-wasmi",
+ "static_assertions",
+ "stellar-strkey 0.0.9",
  "wasmparser",
 ]
 
@@ -1203,13 +1445,28 @@ version = "21.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "242926fe5e0d922f12d3796cd7cd02dd824e5ef1caa088f45fce20b618309f64"
 dependencies = [
- "itertools",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr",
- "syn",
+ "stellar-xdr 21.2.0",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "soroban-env-macros"
+version = "22.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00eff744764ade3bc480e4909e3a581a240091f3d262acdce80b41f7069b2bd9"
+dependencies = [
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "stellar-xdr 22.1.0",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1221,8 +1478,22 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "soroban-env-common",
- "soroban-env-host",
+ "soroban-env-common 21.2.1",
+ "soroban-env-host 21.2.1",
+ "thiserror",
+]
+
+[[package]]
+name = "soroban-ledger-snapshot"
+version = "22.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c30035cf1e8f02f65de3e594b6da113ecdaf1cd134d8480961d62568bb15adaf"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_with",
+ "soroban-env-common 22.1.3",
+ "soroban-env-host 22.1.3",
  "thiserror",
 ]
 
@@ -1241,11 +1512,33 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
- "soroban-env-guest",
- "soroban-env-host",
- "soroban-ledger-snapshot",
- "soroban-sdk-macros",
- "stellar-strkey",
+ "soroban-env-guest 21.2.1",
+ "soroban-env-host 21.2.1",
+ "soroban-ledger-snapshot 21.7.7",
+ "soroban-sdk-macros 21.7.7",
+ "stellar-strkey 0.0.8",
+]
+
+[[package]]
+name = "soroban-sdk"
+version = "22.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff18e8d7ca6d5340a211605ca2c86383bd4dfacc4f8253d72a1573974ffffe69"
+dependencies = [
+ "arbitrary",
+ "bytes-lit",
+ "ctor",
+ "derive_arbitrary",
+ "ed25519-dalek",
+ "rand",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "soroban-env-guest 22.1.3",
+ "soroban-env-host 22.1.3",
+ "soroban-ledger-snapshot 22.0.11",
+ "soroban-sdk-macros 22.0.11",
+ "stellar-strkey 0.0.9",
 ]
 
 [[package]]
@@ -1256,16 +1549,36 @@ checksum = "0974e413731aeff2443f2305b344578b3f1ffd18335a7ba0f0b5d2eb4e94c9ce"
 dependencies = [
  "crate-git-revision",
  "darling 0.20.11",
- "itertools",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "rustc_version",
  "sha2",
- "soroban-env-common",
- "soroban-spec",
- "soroban-spec-rust",
- "stellar-xdr",
- "syn",
+ "soroban-env-common 21.2.1",
+ "soroban-spec 21.7.7",
+ "soroban-spec-rust 21.7.7",
+ "stellar-xdr 21.2.0",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "soroban-sdk-macros"
+version = "22.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b205cd86b34d530db87667bd287fbb194166d79b368227fd842110a914fde8"
+dependencies = [
+ "crate-git-revision",
+ "darling 0.20.11",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "sha2",
+ "soroban-env-common 22.1.3",
+ "soroban-spec 22.0.11",
+ "soroban-spec-rust 22.0.11",
+ "stellar-xdr 22.1.0",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1275,7 +1588,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2c70b20e68cae3ef700b8fa3ae29db1c6a294b311fba66918f90cb8f9fd0a1a"
 dependencies = [
  "base64 0.13.1",
- "stellar-xdr",
+ "stellar-xdr 21.2.0",
+ "thiserror",
+ "wasmparser",
+]
+
+[[package]]
+name = "soroban-spec"
+version = "22.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6a16f2de28852c759f4da5f28cda54ec0d8dfa4c0e6e8cb3495234a72b0cea"
+dependencies = [
+ "base64 0.13.1",
+ "stellar-xdr 22.1.0",
  "thiserror",
  "wasmparser",
 ]
@@ -1290,9 +1615,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2",
- "soroban-spec",
- "stellar-xdr",
- "syn",
+ "soroban-spec 21.7.7",
+ "stellar-xdr 21.2.0",
+ "syn 2.0.117",
+ "thiserror",
+]
+
+[[package]]
+name = "soroban-spec-rust"
+version = "22.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6db5902ab21290dddf63fec4ee95703fe59891a947646e7b8607536f043fc"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "sha2",
+ "soroban-spec 22.0.11",
+ "stellar-xdr 22.1.0",
+ "syn 2.0.117",
  "thiserror",
 ]
 
@@ -1307,6 +1648,13 @@ dependencies = [
  "wasmi_arena",
  "wasmi_core",
  "wasmparser-nostd",
+]
+
+[[package]]
+name = "species-registry"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 21.7.7",
 ]
 
 [[package]]
@@ -1343,6 +1691,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellar-strkey"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e3aa3ed00e70082cb43febc1c2afa5056b9bb3e348bbb43d0cd0aa88a611144"
+dependencies = [
+ "crate-git-revision",
+ "data-encoding",
+ "thiserror",
+]
+
+[[package]]
 name = "stellar-xdr"
 version = "21.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,7 +1714,23 @@ dependencies = [
  "hex",
  "serde",
  "serde_with",
- "stellar-strkey",
+ "stellar-strkey 0.0.8",
+]
+
+[[package]]
+name = "stellar-xdr"
+version = "22.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce69db907e64d1e70a3dce8d4824655d154749426a6132b25395c49136013e4"
+dependencies = [
+ "arbitrary",
+ "base64 0.13.1",
+ "crate-git-revision",
+ "escape-bytes",
+ "hex",
+ "serde",
+ "serde_with",
+ "stellar-strkey 0.0.9",
 ]
 
 [[package]]
@@ -1369,6 +1744,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1398,7 +1784,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1433,17 +1819,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "treasury"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 22.0.11",
+]
+
+[[package]]
 name = "tree-escrow"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 21.7.7",
 ]
 
 [[package]]
 name = "tree-token"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 21.7.7",
 ]
 
 [[package]]
@@ -1502,7 +1895,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1573,7 +1966,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1584,7 +1977,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1628,7 +2021,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1636,12 +2029,26 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zk-location-verifier"
 version = "0.1.0"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 21.7.7",
 ]
 
 [[package]]

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "admin-controls",
     "kyc-attestation",
     "species-registry",
+    "treasury",
 ]
 resolver = "2"
 

--- a/contracts/treasury/Cargo.toml
+++ b/contracts/treasury/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "treasury"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { version = "22.0.1", features = ["alloc"] }
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.1", features = ["testutils", "alloc"] }
+
+[profile.release]
+overflow-checks = true
+lto = true
+codegen-units = 1
+panic = "abort"

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -1,0 +1,391 @@
+#![no_std]
+
+//! Treasury Contract — 2-of-3 Multisig for Platform Fee Withdrawals
+//!
+//! Closes #492
+//!
+//! Platform fees accumulate in this contract. Any withdrawal requires
+//! 2-of-3 signers to approve a `WithdrawProposal` before funds move.
+//!
+//! ## Flow
+//! 1. `initialize(signers, token)` — set three signer addresses.
+//! 2. Anyone calls `deposit(from, amount)` to top up the treasury.
+//! 3. A signer calls `propose(signer, to, amount)` → returns `proposal_id`.
+//! 4. A *different* signer calls `approve(signer, proposal_id)` to reach 2/3.
+//! 5. On the second approval the token transfer executes automatically.
+//! 6. Any signer can `cancel(signer, proposal_id)` an open proposal.
+
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env};
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum ProposalStatus {
+    Open,
+    Executed,
+    Cancelled,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct WithdrawProposal {
+    pub proposer: Address,
+    /// Address of the second signer who approved; None until approved.
+    pub approver: Option<Address>,
+    pub to: Address,
+    pub amount: i128,
+    pub status: ProposalStatus,
+}
+
+#[contracttype]
+enum DataKey {
+    /// (signer_a, signer_b, signer_c)
+    Signers,
+    /// Payment token address
+    Token,
+    /// Auto-incrementing proposal counter
+    NextId,
+    /// Proposal by id
+    Proposal(u32),
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct Treasury;
+
+#[contractimpl]
+impl Treasury {
+    // ── Admin ─────────────────────────────────────────────────────────────────
+
+    /// One-time initialisation.
+    ///
+    /// * `signer_a/b/c` — the three multisig keyholders; must be distinct.
+    /// * `token` — the token contract used to hold and disburse platform fees.
+    pub fn initialize(
+        env: Env,
+        signer_a: Address,
+        signer_b: Address,
+        signer_c: Address,
+        token: Address,
+    ) {
+        if env.storage().instance().has(&DataKey::Signers) {
+            panic!("already initialized");
+        }
+        if signer_a == signer_b || signer_a == signer_c || signer_b == signer_c {
+            panic!("signers must be distinct");
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::Signers, &(signer_a, signer_b, signer_c));
+        env.storage().instance().set(&DataKey::Token, &token);
+        env.storage().instance().set(&DataKey::NextId, &0u32);
+    }
+
+    // ── Deposit ───────────────────────────────────────────────────────────────
+
+    /// Transfer `amount` of the treasury token from `from` into this contract.
+    pub fn deposit(env: Env, from: Address, amount: i128) {
+        from.require_auth();
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+        let token: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Token)
+            .expect("not initialized");
+        token::Client::new(&env, &token).transfer(
+            &from,
+            &env.current_contract_address(),
+            &amount,
+        );
+    }
+
+    // ── Multisig flow ─────────────────────────────────────────────────────────
+
+    /// A signer opens a withdrawal proposal.  Returns the new `proposal_id`.
+    pub fn propose(env: Env, signer: Address, to: Address, amount: i128) -> u32 {
+        signer.require_auth();
+        Self::assert_signer(&env, &signer);
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+
+        let id: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextId)
+            .expect("not initialized");
+
+        let proposal = WithdrawProposal {
+            proposer: signer,
+            approver: None,
+            to,
+            amount,
+            status: ProposalStatus::Open,
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::Proposal(id), &proposal);
+        env.storage()
+            .instance()
+            .set(&DataKey::NextId, &(id + 1));
+
+        env.events()
+            .publish((symbol_short!("proposed"),), (id,));
+
+        id
+    }
+
+    /// A *different* signer approves an open proposal.
+    /// Reaching 2 approvals immediately executes the transfer.
+    pub fn approve(env: Env, signer: Address, proposal_id: u32) {
+        signer.require_auth();
+        Self::assert_signer(&env, &signer);
+
+        let mut proposal: WithdrawProposal = env
+            .storage()
+            .instance()
+            .get(&DataKey::Proposal(proposal_id))
+            .expect("proposal not found");
+
+        if proposal.status != ProposalStatus::Open {
+            panic!("proposal is not open");
+        }
+        if proposal.proposer == signer {
+            panic!("proposer cannot also approve");
+        }
+        if proposal.approver.is_some() {
+            panic!("already approved");
+        }
+
+        // ── Execute transfer ──────────────────────────────────────────────────
+        let token: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Token)
+            .expect("not initialized");
+
+        token::Client::new(&env, &token).transfer(
+            &env.current_contract_address(),
+            &proposal.to,
+            &proposal.amount,
+        );
+
+        proposal.approver = Some(signer);
+        proposal.status = ProposalStatus::Executed;
+        env.storage()
+            .instance()
+            .set(&DataKey::Proposal(proposal_id), &proposal);
+
+        env.events()
+            .publish((symbol_short!("executed"),), (proposal_id,));
+    }
+
+    /// Any signer can cancel an open proposal.
+    pub fn cancel(env: Env, signer: Address, proposal_id: u32) {
+        signer.require_auth();
+        Self::assert_signer(&env, &signer);
+
+        let mut proposal: WithdrawProposal = env
+            .storage()
+            .instance()
+            .get(&DataKey::Proposal(proposal_id))
+            .expect("proposal not found");
+
+        if proposal.status != ProposalStatus::Open {
+            panic!("proposal is not open");
+        }
+
+        proposal.status = ProposalStatus::Cancelled;
+        env.storage()
+            .instance()
+            .set(&DataKey::Proposal(proposal_id), &proposal);
+
+        env.events()
+            .publish((symbol_short!("cancelled"),), (proposal_id,));
+    }
+
+    // ── Queries ───────────────────────────────────────────────────────────────
+
+    /// Return a proposal by id.
+    pub fn get_proposal(env: Env, proposal_id: u32) -> WithdrawProposal {
+        env.storage()
+            .instance()
+            .get(&DataKey::Proposal(proposal_id))
+            .expect("proposal not found")
+    }
+
+    /// Return the current treasury token balance of this contract.
+    pub fn balance(env: Env) -> i128 {
+        let token: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Token)
+            .expect("not initialized");
+        token::Client::new(&env, &token).balance(&env.current_contract_address())
+    }
+
+    // ── Internal helpers ──────────────────────────────────────────────────────
+
+    fn assert_signer(env: &Env, addr: &Address) {
+        let (a, b, c): (Address, Address, Address) = env
+            .storage()
+            .instance()
+            .get(&DataKey::Signers)
+            .expect("not initialized");
+        if *addr != a && *addr != b && *addr != c {
+            panic!("not a signer");
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    use crate::{ProposalStatus, Treasury, TreasuryClient};
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    fn deploy_token(env: &Env, admin: &Address) -> Address {
+        env.register_stellar_asset_contract_v2(admin.clone()).address()
+    }
+
+    fn mint(env: &Env, token: &Address, to: &Address, amount: i128) {
+        soroban_sdk::token::StellarAssetClient::new(env, token).mint(to, &amount);
+    }
+
+    struct Ctx {
+        env: Env,
+        contract: Address,
+        sa: Address,
+        sb: Address,
+        sc: Address,
+        token: Address,
+    }
+
+    fn setup() -> Ctx {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let token = deploy_token(&env, &admin);
+        let sa = Address::generate(&env);
+        let sb = Address::generate(&env);
+        let sc = Address::generate(&env);
+        let contract = env.register(Treasury, ());
+        TreasuryClient::new(&env, &contract).initialize(&sa, &sb, &sc, &token);
+        Ctx { env, contract, sa, sb, sc, token }
+    }
+
+    // ── happy path ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_propose_and_approve_executes_transfer() {
+        let Ctx { env, contract, sa, sb, token, .. } = setup();
+        let client = TreasuryClient::new(&env, &contract);
+        mint(&env, &token, &contract, 1_000);
+
+        let recipient = Address::generate(&env);
+        let proposal_id = client.propose(&sa, &recipient, &500);
+        assert_eq!(soroban_sdk::token::Client::new(&env, &token).balance(&recipient), 0);
+
+        client.approve(&sb, &proposal_id);
+
+        assert_eq!(soroban_sdk::token::Client::new(&env, &token).balance(&recipient), 500);
+        assert_eq!(client.get_proposal(&proposal_id).status, ProposalStatus::Executed);
+    }
+
+    #[test]
+    fn test_third_signer_can_also_approve() {
+        let Ctx { env, contract, sa, sc, token, .. } = setup();
+        let client = TreasuryClient::new(&env, &contract);
+        mint(&env, &token, &contract, 1_000);
+
+        let recipient = Address::generate(&env);
+        let proposal_id = client.propose(&sa, &recipient, &300);
+        client.approve(&sc, &proposal_id);
+
+        assert_eq!(soroban_sdk::token::Client::new(&env, &token).balance(&recipient), 300);
+    }
+
+    #[test]
+    fn test_deposit_increases_balance() {
+        let Ctx { env, contract, token, .. } = setup();
+        let client = TreasuryClient::new(&env, &contract);
+        let funder = Address::generate(&env);
+        mint(&env, &token, &funder, 2_000);
+        client.deposit(&funder, &2_000);
+        assert_eq!(client.balance(), 2_000);
+    }
+
+    #[test]
+    fn test_cancel_open_proposal() {
+        let Ctx { env, contract, sa, token, .. } = setup();
+        let client = TreasuryClient::new(&env, &contract);
+        mint(&env, &token, &contract, 1_000);
+        let recipient = Address::generate(&env);
+        let proposal_id = client.propose(&sa, &recipient, &100);
+        client.cancel(&sa, &proposal_id);
+        assert_eq!(client.get_proposal(&proposal_id).status, ProposalStatus::Cancelled);
+    }
+
+    // ── error paths ───────────────────────────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "already initialized")]
+    fn test_double_init_rejected() {
+        let Ctx { env, contract, sa, sb, sc, token } = setup();
+        TreasuryClient::new(&env, &contract).initialize(&sa, &sb, &sc, &token);
+    }
+
+    #[test]
+    #[should_panic(expected = "signers must be distinct")]
+    fn test_duplicate_signers_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let token = deploy_token(&env, &admin);
+        let sa = Address::generate(&env);
+        let contract = env.register(Treasury, ());
+        TreasuryClient::new(&env, &contract).initialize(&sa, &sa, &sa, &token);
+    }
+
+    #[test]
+    #[should_panic(expected = "proposer cannot also approve")]
+    fn test_proposer_cannot_approve_own_proposal() {
+        let Ctx { env, contract, sa, token, .. } = setup();
+        let client = TreasuryClient::new(&env, &contract);
+        mint(&env, &token, &contract, 1_000);
+        let recipient = Address::generate(&env);
+        let proposal_id = client.propose(&sa, &recipient, &100);
+        client.approve(&sa, &proposal_id);
+    }
+
+    #[test]
+    #[should_panic(expected = "not a signer")]
+    fn test_non_signer_cannot_propose() {
+        let Ctx { env, contract, token, .. } = setup();
+        let client = TreasuryClient::new(&env, &contract);
+        mint(&env, &token, &contract, 1_000);
+        let outsider = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        client.propose(&outsider, &recipient, &100);
+    }
+
+    #[test]
+    #[should_panic(expected = "proposal is not open")]
+    fn test_approve_cancelled_proposal_rejected() {
+        let Ctx { env, contract, sa, sb, token, .. } = setup();
+        let client = TreasuryClient::new(&env, &contract);
+        mint(&env, &token, &contract, 1_000);
+        let recipient = Address::generate(&env);
+        let proposal_id = client.propose(&sa, &recipient, &100);
+        client.cancel(&sa, &proposal_id);
+        client.approve(&sb, &proposal_id);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #492

Replaces the single-admin platform-fee withdrawal with a **2-of-3 multisig treasury** Soroban contract.

## Changes

- **New contract:** `contracts/treasury/`
  - `initialize(signer_a, signer_b, signer_c, token)` — one-time setup, all signers must be distinct
  - `deposit(from, amount)` — anyone can fund the treasury (platform fee collection)
  - `propose(signer, to, amount) → proposal_id` — a signer opens a withdrawal request
  - `approve(signer, proposal_id)` — a *different* signer approves; transfer executes automatically on 2nd approval
  - `cancel(signer, proposal_id)` — any signer can cancel an open proposal
  - `get_proposal(proposal_id)` / `balance()` — read-only queries
- **Updated:** `contracts/Cargo.toml` — added `treasury` to workspace members
- **Updated:** `contracts/Cargo.lock` — regenerated

## Security properties

| Property | Enforcement |
|---|---|
| 2-of-3 threshold | Proposer ≠ Approver; transfer fires on 2nd auth |
| Signer uniqueness | Checked at `initialize` time |
| Re-init prevention | Panics if already initialized |
| Self-approve prevention | Panics if `proposer == signer` on `approve` |
| Single execution | Status moves Open → Executed; subsequent ops panic |
| Cancellation | Open → Cancelled; approve after cancel panics |

## Tests

9/9 passing (`cargo test -p treasury`):

- `test_propose_and_approve_executes_transfer` — happy path, funds reach recipient
- `test_third_signer_can_also_approve` — any valid 2-of-3 pair works
- `test_deposit_increases_balance`
- `test_cancel_open_proposal`
- `test_double_init_rejected`
- `test_duplicate_signers_rejected`
- `test_proposer_cannot_approve_own_proposal`
- `test_non_signer_cannot_propose`
- `test_approve_cancelled_proposal_rejected`

## CI

The `contracts.yml` workflow builds WASM and runs `cargo test` on every PR touching `contracts/**`. This PR only modifies contracts.