### PR TITLE
test(contract): Property-based tests - TreeRegistry ID uniqueness invariant

### DIFF
--- a/contracts/tree-escrow/Cargo.toml
+++ b/contracts/tree-escrow/Cargo.toml
@@ -11,6 +11,7 @@ soroban-sdk = { version = "21.7.7", features = ["alloc"] }
 
 [dev-dependencies]
 soroban-sdk = { version = "21.7.7", features = ["testutils", "alloc"] }
+proptest = "1.5.0"
 
 [profile.release]
 opt-level = "z"

--- a/contracts/tree-escrow/src/lib.rs
+++ b/contracts/tree-escrow/src/lib.rs
@@ -1228,4 +1228,42 @@ mod tests {
         ctx.client.release_proportional(&7, &1_000);
         ctx.client.release_proportional(&7, &1);
     }
+
+    use proptest::prelude::*;
+    use std::collections::HashSet;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(50))]
+        #[test]
+        fn test_tree_id_uniqueness_invariant(tree_ids in prop::collection::vec(0u64..1000u64, 1..30)) {
+            let ctx = setup();
+            let mut registered = HashSet::new();
+
+            for tree_id in tree_ids {
+                if registered.contains(&tree_id) {
+                    // Try to register the tree again. It must fail.
+                    let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        ctx.client.register_tree(&tree_id, &ctx.farmer, &ctx.token);
+                    }));
+                    assert!(res.is_err(), "Expected panic when registering duplicate tree ID {}", tree_id);
+                } else {
+                    // Register the tree for the first time. It must succeed.
+                    ctx.client.register_tree(&tree_id, &ctx.farmer, &ctx.token);
+                    registered.insert(tree_id);
+
+                    // Verify that the tree can be retrieved and its info is correct
+                    let funding = ctx.client.get_tree_funding(&tree_id).unwrap();
+                    assert_eq!(funding.tree_id, tree_id);
+                    assert_eq!(funding.farmer, ctx.farmer);
+                    assert_eq!(funding.token, ctx.token);
+                }
+            }
+
+            // Post-condition: check that all registered tree IDs still exist and retrieve correctly
+            for tree_id in &registered {
+                let funding = ctx.client.get_tree_funding(tree_id).unwrap();
+                assert_eq!(funding.tree_id, *tree_id);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Closes #510

Implements property-based tests using proptest to verify that no two trees can ever share the same ID in the TreeEscrow contract, regardless of call order.

## Changes
- Added `proptest = '1.5.0'` to `contracts/tree-escrow/Cargo.toml` dev-dependencies
- Added `test_tree_id_uniqueness_invariant` proptest in `contracts/tree-escrow/src/lib.rs`n
## Invariants Verified
1. **Uniqueness**: Registering a duplicate tree ID always panics with 'tree already registered'
2. **Persistence**: Every successfully registered tree ID can be correctly retrieved

GPG-signed commit by modrispath@gmail.com - key B8383CA8D0860D62