### PR TITLE
feat(backend): PostgreSQL schema - trees, planters, progress_updates, disputes

### DIFF
--- a/contracts/tree-escrow/Cargo.toml
+++ b/contracts/tree-escrow/Cargo.toml
@@ -11,6 +11,7 @@ soroban-sdk = { version = "21.7.7", features = ["alloc"] }
 
 [dev-dependencies]
 soroban-sdk = { version = "21.7.7", features = ["testutils", "alloc"] }
+proptest = "1.5.0"
 
 [profile.release]
 opt-level = "z"

--- a/contracts/tree-escrow/src/lib.rs
+++ b/contracts/tree-escrow/src/lib.rs
@@ -1228,4 +1228,42 @@ mod tests {
         ctx.client.release_proportional(&7, &1_000);
         ctx.client.release_proportional(&7, &1);
     }
+
+    use proptest::prelude::*;
+    use std::collections::HashSet;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(50))]
+        #[test]
+        fn test_tree_id_uniqueness_invariant(tree_ids in prop::collection::vec(0u64..1000u64, 1..30)) {
+            let ctx = setup();
+            let mut registered = HashSet::new();
+
+            for tree_id in tree_ids {
+                if registered.contains(&tree_id) {
+                    // Try to register the tree again. It must fail.
+                    let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        ctx.client.register_tree(&tree_id, &ctx.farmer, &ctx.token);
+                    }));
+                    assert!(res.is_err(), "Expected panic when registering duplicate tree ID {}", tree_id);
+                } else {
+                    // Register the tree for the first time. It must succeed.
+                    ctx.client.register_tree(&tree_id, &ctx.farmer, &ctx.token);
+                    registered.insert(tree_id);
+
+                    // Verify that the tree can be retrieved and its info is correct
+                    let funding = ctx.client.get_tree_funding(&tree_id).unwrap();
+                    assert_eq!(funding.tree_id, tree_id);
+                    assert_eq!(funding.farmer, ctx.farmer);
+                    assert_eq!(funding.token, ctx.token);
+                }
+            }
+
+            // Post-condition: check that all registered tree IDs still exist and retrieve correctly
+            for tree_id in &registered {
+                let funding = ctx.client.get_tree_funding(tree_id).unwrap();
+                assert_eq!(funding.tree_id, *tree_id);
+            }
+        }
+    }
 }

--- a/db/migrations/003-006_rollback.sql
+++ b/db/migrations/003-006_rollback.sql
@@ -1,0 +1,17 @@
+-- Rollback: 003-006_drop_trees_planters_progress_disputes.sql
+-- Closes #546
+--
+-- Reverses migrations 003–006 in dependency order.
+-- Run this to roll back the trees, planters, progress_updates, and disputes
+-- tables together. Existing data WILL be lost.
+
+-- Drop in reverse dependency order ───────────────────────────────────────────
+
+DROP TABLE IF EXISTS disputes         CASCADE;
+DROP TABLE IF EXISTS progress_updates CASCADE;
+DROP TABLE IF EXISTS trees            CASCADE;
+DROP TABLE IF EXISTS planters         CASCADE;
+
+-- Drop custom enum types introduced in migration 006
+DROP TYPE IF EXISTS dispute_status   CASCADE;
+DROP TYPE IF EXISTS dispute_category CASCADE;

--- a/db/migrations/003_create_planters.sql
+++ b/db/migrations/003_create_planters.sql
@@ -1,0 +1,51 @@
+-- Migration: 003_create_planters.sql
+-- Closes #546
+--
+-- Stores off-chain planter (farmer) metadata, linked to a Stellar wallet.
+-- Soft-deleted via deleted_at so historical planting records remain intact.
+
+-- UP ─────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS planters (
+  -- Internal surrogate key
+  id                BIGSERIAL     PRIMARY KEY,
+
+  -- Stellar public key — unique identity for a planter
+  stellar_address   TEXT          NOT NULL UNIQUE,
+
+  -- Display name (from onboarding / KYC)
+  full_name         TEXT          NOT NULL,
+
+  -- ISO 3166-1 alpha-2 country code, e.g. 'NG', 'GH', 'KE'
+  country_code      CHAR(2)       NOT NULL,
+
+  -- Approximate region / state (for map clustering)
+  region            TEXT          NOT NULL,
+
+  -- GPS coordinates of the planter's primary farm (fuzzed for privacy)
+  lat               NUMERIC(9, 6),
+  lng               NUMERIC(9, 6),
+
+  -- Phone number (E.164 format) for SMS verification
+  phone_e164        TEXT,
+
+  -- KYC / onboarding status
+  kyc_status        TEXT          NOT NULL DEFAULT 'pending'
+    CHECK (kyc_status IN ('pending', 'verified', 'rejected', 'suspended')),
+
+  -- Optional link to an off-chain identity document hash (IPFS CID or SHA-256)
+  identity_hash     TEXT,
+
+  -- Timestamps
+  created_at        TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+
+  -- Soft delete — set to NOW() to deactivate; NULL means active
+  deleted_at        TIMESTAMPTZ
+);
+
+-- Indexes for common look-ups
+CREATE INDEX IF NOT EXISTS idx_planters_stellar    ON planters (stellar_address);
+CREATE INDEX IF NOT EXISTS idx_planters_country    ON planters (country_code);
+CREATE INDEX IF NOT EXISTS idx_planters_kyc        ON planters (kyc_status);
+CREATE INDEX IF NOT EXISTS idx_planters_active     ON planters (deleted_at) WHERE deleted_at IS NULL;

--- a/db/migrations/004_create_trees.sql
+++ b/db/migrations/004_create_trees.sql
@@ -1,0 +1,61 @@
+-- Migration: 004_create_trees.sql
+-- Closes #546
+--
+-- Stores cached tree records indexed from the on-chain TreeEscrow contract.
+-- Keyed on (contract_address, token_id) for idempotent re-indexing.
+-- Soft-deleted via deleted_at.
+
+-- UP ─────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS trees (
+  -- Internal surrogate key
+  id                  BIGSERIAL       PRIMARY KEY,
+
+  -- On-chain identity — (contract_address, token_id) must be globally unique
+  contract_address    TEXT            NOT NULL,
+  token_id            BIGINT          NOT NULL,
+  CONSTRAINT uq_trees_contract_token UNIQUE (contract_address, token_id),
+
+  -- Human-readable tree ID (e.g. 'HRV-2024-0001')
+  tree_ref            TEXT            NOT NULL UNIQUE,
+
+  -- FK to planters table (who planted this tree)
+  planter_id          BIGINT          REFERENCES planters (id) ON DELETE SET NULL,
+
+  -- FK to species catalogue
+  species_slug        TEXT            REFERENCES species_catalogue (slug) ON DELETE SET NULL,
+
+  -- Geographic location (fuzzed ±0.01° for privacy)
+  lat                 NUMERIC(9, 6)   NOT NULL,
+  lng                 NUMERIC(9, 6)   NOT NULL,
+  region              TEXT            NOT NULL,
+  country_code        CHAR(2)         NOT NULL,
+
+  -- Lifecycle status — mirrors contract state
+  status              TEXT            NOT NULL DEFAULT 'funded'
+    CHECK (status IN ('funded', 'planted', 'verified', 'completed', 'failed')),
+
+  -- Stellar escrow account holding USDC for this tree
+  escrow_account      TEXT,
+
+  -- Stellar tx hash of the funding event (for auditability)
+  funding_tx_hash     TEXT            REFERENCES indexed_transactions (tx_hash),
+
+  -- Timestamps
+  planted_at          TIMESTAMPTZ,
+  verified_at         TIMESTAMPTZ,
+  completed_at        TIMESTAMPTZ,
+  created_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+  updated_at          TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+
+  -- Soft delete
+  deleted_at          TIMESTAMPTZ
+);
+
+-- Indexes for REST API queries (GET /trees, GET /trees/:id)
+CREATE INDEX IF NOT EXISTS idx_trees_status         ON trees (status);
+CREATE INDEX IF NOT EXISTS idx_trees_planter        ON trees (planter_id);
+CREATE INDEX IF NOT EXISTS idx_trees_species        ON trees (species_slug);
+CREATE INDEX IF NOT EXISTS idx_trees_country        ON trees (country_code);
+CREATE INDEX IF NOT EXISTS idx_trees_created        ON trees (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_trees_active         ON trees (deleted_at) WHERE deleted_at IS NULL;

--- a/db/migrations/005_create_progress_updates.sql
+++ b/db/migrations/005_create_progress_updates.sql
@@ -1,0 +1,70 @@
+-- Migration: 005_create_progress_updates.sql
+-- Closes #546
+--
+-- High-volume event log: every on-chain status change, photo submission, or
+-- GPS ping for a tree is recorded here.
+--
+-- Indexed on (tree_id, created_at DESC) for efficient timeline pagination.
+-- paging_token is the Horizon operation paging token — used to prevent
+-- duplicate ingestion on indexer restarts (idempotency key).
+
+-- UP ─────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS progress_updates (
+  -- Internal surrogate key
+  id                BIGSERIAL       PRIMARY KEY,
+
+  -- FK to the tree this update belongs to
+  tree_id           BIGINT          NOT NULL REFERENCES trees (id) ON DELETE CASCADE,
+
+  -- Horizon paging token of the source operation — unique ingestion guard
+  paging_token      TEXT            NOT NULL UNIQUE,
+
+  -- Type of update
+  update_type       TEXT            NOT NULL
+    CHECK (update_type IN (
+      'status_change',   -- contract state transition
+      'photo_submitted', -- planter submitted a photo proof
+      'gps_ping',        -- GPS location evidence submitted
+      'survival_check',  -- periodic survival verification
+      'note'             -- free-form admin note
+    )),
+
+  -- Previous and new status (populated for status_change updates)
+  from_status       TEXT
+    CHECK (from_status IS NULL OR from_status IN ('funded', 'planted', 'verified', 'completed', 'failed')),
+  to_status         TEXT
+    CHECK (to_status IS NULL OR to_status IN ('funded', 'planted', 'verified', 'completed', 'failed')),
+
+  -- GPS coordinates reported in this update (may differ from tree.lat/lng)
+  lat               NUMERIC(9, 6),
+  lng               NUMERIC(9, 6),
+
+  -- Off-chain media: IPFS CID or signed URL for photo evidence
+  media_url         TEXT,
+
+  -- IPFS CID of the raw photo (immutable audit link)
+  ipfs_cid          TEXT,
+
+  -- Free-form metadata (e.g. survival score, verifier notes)
+  metadata          JSONB           NOT NULL DEFAULT '{}',
+
+  -- Stellar account that submitted the update
+  submitted_by      TEXT,
+
+  -- Ledger timestamp of the source Horizon operation
+  created_at        TIMESTAMPTZ     NOT NULL DEFAULT NOW()
+);
+
+-- Primary access pattern: chronological timeline for a single tree
+CREATE INDEX IF NOT EXISTS idx_pu_tree_created   ON progress_updates (tree_id, created_at DESC);
+
+-- Indexer cursor: resume from last processed paging_token per tree
+CREATE INDEX IF NOT EXISTS idx_pu_paging_token   ON progress_updates (paging_token);
+
+-- Allow filtering by update type across all trees
+CREATE INDEX IF NOT EXISTS idx_pu_update_type    ON progress_updates (update_type);
+
+-- Partial index for unprocessed survival checks (operational monitoring)
+CREATE INDEX IF NOT EXISTS idx_pu_survival       ON progress_updates (created_at DESC)
+  WHERE update_type = 'survival_check';

--- a/db/migrations/006_create_disputes.sql
+++ b/db/migrations/006_create_disputes.sql
@@ -1,0 +1,74 @@
+-- Migration: 006_create_disputes.sql
+-- Closes #546
+--
+-- Records formal disputes raised against a tree record — e.g. planting fraud,
+-- survival failure, or escrow release disagreement.
+--
+-- Uses a proper status enum covering the full dispute workflow rather than a
+-- loose TEXT column, so invalid state transitions can be caught at the DB layer.
+
+-- UP ─────────────────────────────────────────────────────────────────────────
+
+-- Dispute status lifecycle:
+--   open → under_review → resolved | escalated → closed
+CREATE TYPE dispute_status AS ENUM (
+  'open',
+  'under_review',
+  'resolved',
+  'escalated',
+  'closed'
+);
+
+-- Dispute category
+CREATE TYPE dispute_category AS ENUM (
+  'planting_fraud',      -- Tree never planted / photo fake
+  'survival_failure',    -- Tree died before completion
+  'escrow_release',      -- Disagreement over escrow payout
+  'gps_mismatch',        -- GPS coordinates do not match claimed location
+  'admin_error',         -- Data entry / indexing mistake
+  'other'
+);
+
+CREATE TABLE IF NOT EXISTS disputes (
+  -- Internal surrogate key
+  id                  BIGSERIAL         PRIMARY KEY,
+
+  -- The tree this dispute is about
+  tree_id             BIGINT            NOT NULL REFERENCES trees (id) ON DELETE CASCADE,
+
+  -- Stellar account of the party raising the dispute (sponsor, planter, or admin)
+  raised_by           TEXT              NOT NULL,
+
+  -- Category and free-form description
+  category            dispute_category  NOT NULL,
+  description         TEXT              NOT NULL,
+
+  -- Evidence: IPFS CID or signed URL of supporting document / photo
+  evidence_url        TEXT,
+  evidence_ipfs_cid   TEXT,
+
+  -- Workflow state machine
+  status              dispute_status    NOT NULL DEFAULT 'open',
+
+  -- Stellar account of the admin / arbitrator handling this dispute
+  assigned_to         TEXT,
+
+  -- Resolution notes written by the arbitrator
+  resolution_notes    TEXT,
+
+  -- Stellar tx hash of any on-chain action taken to resolve (e.g. refund)
+  resolution_tx_hash  TEXT              REFERENCES indexed_transactions (tx_hash),
+
+  -- Timestamps
+  created_at          TIMESTAMPTZ       NOT NULL DEFAULT NOW(),
+  updated_at          TIMESTAMPTZ       NOT NULL DEFAULT NOW(),
+  resolved_at         TIMESTAMPTZ
+);
+
+-- Common query patterns
+CREATE INDEX IF NOT EXISTS idx_disputes_tree        ON disputes (tree_id);
+CREATE INDEX IF NOT EXISTS idx_disputes_status      ON disputes (status);
+CREATE INDEX IF NOT EXISTS idx_disputes_raised_by   ON disputes (raised_by);
+CREATE INDEX IF NOT EXISTS idx_disputes_assigned    ON disputes (assigned_to) WHERE assigned_to IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_disputes_open        ON disputes (created_at DESC) WHERE status = 'open';
+CREATE INDEX IF NOT EXISTS idx_disputes_category    ON disputes (category);

--- a/db/seeds/seed_trees_planters.sql
+++ b/db/seeds/seed_trees_planters.sql
@@ -1,0 +1,128 @@
+-- Seed: seed_trees_planters.sql
+-- Closes #546
+--
+-- Provides realistic local dev data for planters, trees, progress_updates,
+-- and disputes. Safe to re-run (uses ON CONFLICT DO NOTHING throughout).
+-- Run AFTER all migrations 001-006 have been applied.
+
+-- ── Planters ─────────────────────────────────────────────────────────────────
+
+INSERT INTO planters
+  (stellar_address, full_name, country_code, region, lat, lng, phone_e164, kyc_status)
+VALUES
+  ('GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+   'Aminu Musa',         'NG', 'Kano, Nigeria',         12.04,  8.48, '+2348012345678', 'verified'),
+  ('GBSJ7KFU2NXACVHVN2VWQIXIV5FWH6A423YVXAGKJUOTNUVWD5CMKEZ',
+   'Fatima Yusuf',       'NG', 'Kaduna, Nigeria',       10.48,  7.40, '+2348023456789', 'verified'),
+  ('GD6WNTESP5P7UDPGM3OODAQGAMM3TBPQ7GJICNPQMHLSXP56BXE4P24',
+   'Kwame Asante',       'GH', 'Greater Accra, Ghana',   5.58, -0.18, '+233244567890',  'verified'),
+  ('GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZEP0MOQPZJQ5CGBGVRFG',
+   'Aisha Nakato',       'UG', 'Kampala, Uganda',        0.30, 32.55, '+256712345678',  'pending'),
+  ('GBVV2QWHWUQ7PGCDZ4JLJNBXW6CTMFOBGRD4S5XBGCRM53JXDTNNGKC',
+   'James Mwangi',       'KE', 'Nairobi, Kenya',        -1.27, 36.78, '+254712345678',  'verified')
+ON CONFLICT (stellar_address) DO NOTHING;
+
+-- ── Trees ─────────────────────────────────────────────────────────────────────
+
+INSERT INTO trees
+  (contract_address, token_id, tree_ref, planter_id, species_slug,
+   lat, lng, region, country_code, status, escrow_account,
+   planted_at, verified_at)
+VALUES
+  -- Kano – Teak (planter 1)
+  ('CAQJKECMBRDCGQH7RFVKF4JY4LQWMOJJOPSKL2OEKM5YPM2QWBQVWBJ', 1,
+   'HRV-2024-0001',
+   (SELECT id FROM planters WHERE stellar_address = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN'),
+   'teak', 12.04, 8.48, 'Kano, Nigeria', 'NG', 'verified',
+   'GBW4QY56QDXJL7SCZMBNLXUIMCZ7V6LNJRHE7PBXF7RMEZGMJX5RJBJ',
+   '2024-03-12T08:00:00Z', '2024-06-12T08:00:00Z'),
+
+  -- Kano – Moringa (planter 1)
+  ('CAQJKECMBRDCGQH7RFVKF4JY4LQWMOJJOPSKL2OEKM5YPM2QWBQVWBJ', 2,
+   'HRV-2024-0002',
+   (SELECT id FROM planters WHERE stellar_address = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN'),
+   'moringa', 11.98, 8.55, 'Kano, Nigeria', 'NG', 'planted', NULL,
+   '2024-05-20T10:30:00Z', NULL),
+
+  -- Kaduna – Eucalyptus (planter 2)
+  ('CAQJKECMBRDCGQH7RFVKF4JY4LQWMOJJOPSKL2OEKM5YPM2QWBQVWBJ', 3,
+   'HRV-2024-0003',
+   (SELECT id FROM planters WHERE stellar_address = 'GBSJ7KFU2NXACVHVN2VWQIXIV5FWH6A423YVXAGKJUOTNUVWD5CMKEZ'),
+   'eucalyptus', 10.48, 7.40, 'Kaduna, Nigeria', 'NG', 'completed', NULL,
+   '2023-11-05T14:00:00Z', '2024-02-05T14:00:00Z'),
+
+  -- Greater Accra – Mangrove (planter 3)
+  ('CAQJKECMBRDCGQH7RFVKF4JY4LQWMOJJOPSKL2OEKM5YPM2QWBQVWBJ', 4,
+   'HRV-2024-0004',
+   (SELECT id FROM planters WHERE stellar_address = 'GD6WNTESP5P7UDPGM3OODAQGAMM3TBPQ7GJICNPQMHLSXP56BXE4P24'),
+   'mangrove', 5.58, -0.18, 'Greater Accra, Ghana', 'GH', 'verified', NULL,
+   '2024-01-18T09:15:00Z', '2024-04-18T09:15:00Z'),
+
+  -- Kampala – Mangrove — failed (planter 4, pending KYC)
+  ('CAQJKECMBRDCGQH7RFVKF4JY4LQWMOJJOPSKL2OEKM5YPM2QWBQVWBJ', 5,
+   'HRV-2024-0005',
+   (SELECT id FROM planters WHERE stellar_address = 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZEP0MOQPZJQ5CGBGVRFG'),
+   'mangrove', 0.30, 32.55, 'Kampala, Uganda', 'UG', 'failed', NULL,
+   '2023-09-14T16:20:00Z', NULL),
+
+  -- Nairobi – Teak (planter 5)
+  ('CAQJKECMBRDCGQH7RFVKF4JY4LQWMOJJOPSKL2OEKM5YPM2QWBQVWBJ', 6,
+   'HRV-2024-0006',
+   (SELECT id FROM planters WHERE stellar_address = 'GBVV2QWHWUQ7PGCDZ4JLJNBXW6CTMFOBGRD4S5XBGCRM53JXDTNNGKC'),
+   'teak', -1.27, 36.78, 'Nairobi, Kenya', 'KE', 'planted', NULL,
+   '2024-02-28T11:00:00Z', NULL)
+ON CONFLICT (contract_address, token_id) DO NOTHING;
+
+-- ── Progress Updates ──────────────────────────────────────────────────────────
+
+INSERT INTO progress_updates
+  (tree_id, paging_token, update_type, from_status, to_status, lat, lng,
+   media_url, submitted_by, created_at)
+VALUES
+  -- Tree 1 (HRV-2024-0001): funded → planted → verified
+  ((SELECT id FROM trees WHERE tree_ref = 'HRV-2024-0001'),
+   'HRV-0001-TOKEN-001', 'status_change', 'funded', 'planted',
+   12.04, 8.48, NULL,
+   'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+   '2024-03-12T08:00:00Z'),
+
+  ((SELECT id FROM trees WHERE tree_ref = 'HRV-2024-0001'),
+   'HRV-0001-TOKEN-002', 'photo_submitted', NULL, NULL,
+   12.04, 8.48, 'https://ipfs.io/ipfs/QmPlantPhotoTeak001',
+   'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+   '2024-03-15T10:30:00Z'),
+
+  ((SELECT id FROM trees WHERE tree_ref = 'HRV-2024-0001'),
+   'HRV-0001-TOKEN-003', 'status_change', 'planted', 'verified',
+   12.04, 8.48, NULL,
+   'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+   '2024-06-12T08:00:00Z'),
+
+  -- Tree 5 (HRV-2024-0005): planted → failed
+  ((SELECT id FROM trees WHERE tree_ref = 'HRV-2024-0005'),
+   'HRV-0005-TOKEN-001', 'status_change', 'planted', 'failed',
+   0.30, 32.55, NULL,
+   'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZEP0MOQPZJQ5CGBGVRFG',
+   '2023-12-14T16:20:00Z')
+ON CONFLICT (paging_token) DO NOTHING;
+
+-- ── Disputes ──────────────────────────────────────────────────────────────────
+
+INSERT INTO disputes
+  (tree_id, raised_by, category, description, status, assigned_to, created_at)
+VALUES
+  -- Dispute on the failed Kampala tree
+  ((SELECT id FROM trees WHERE tree_ref = 'HRV-2024-0005'),
+   'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+   'survival_failure',
+   'Tree reported as failed without sufficient photo evidence. Requesting re-verification.',
+   'open', NULL, '2024-01-10T09:00:00Z'),
+
+  -- Resolved GPS mismatch on Kano tree
+  ((SELECT id FROM trees WHERE tree_ref = 'HRV-2024-0001'),
+   'GBSJ7KFU2NXACVHVN2VWQIXIV5FWH6A423YVXAGKJUOTNUVWD5CMKEZ',
+   'gps_mismatch',
+   'GPS coordinates differ by >500m from expected farm boundary.',
+   'resolved', 'GBVV2QWHWUQ7PGCDZ4JLJNBXW6CTMFOBGRD4S5XBGCRM53JXDTNNGKC',
+   '2024-04-01T11:00:00Z')
+ON CONFLICT DO NOTHING;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,0 +1,124 @@
+/**
+ * TypeScript row types for the trees / planters / progress_updates / disputes
+ * schema introduced in migrations 003–006.
+ *
+ * These are plain data-transfer types (no ORM). Column names match the SQL
+ * schema exactly. Use `getPool().query(...)` from @/lib/db/client to query.
+ *
+ * Closes #546
+ */
+
+// ── Planters (migration 003) ──────────────────────────────────────────────────
+
+export type KycStatus = 'pending' | 'verified' | 'rejected' | 'suspended';
+
+export interface PlanterRow {
+  id: number;
+  stellar_address: string;
+  full_name: string;
+  country_code: string;
+  region: string;
+  lat: string | null;    // NUMERIC returned as string by pg driver
+  lng: string | null;
+  phone_e164: string | null;
+  kyc_status: KycStatus;
+  identity_hash: string | null;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+}
+
+// ── Trees (migration 004) ─────────────────────────────────────────────────────
+
+export type TreeStatus = 'funded' | 'planted' | 'verified' | 'completed' | 'failed';
+
+export interface TreeRow {
+  id: number;
+  contract_address: string;
+  token_id: number;
+  tree_ref: string;
+  planter_id: number | null;
+  species_slug: string | null;
+  lat: string;           // NUMERIC
+  lng: string;
+  region: string;
+  country_code: string;
+  status: TreeStatus;
+  escrow_account: string | null;
+  funding_tx_hash: string | null;
+  planted_at: Date | null;
+  verified_at: Date | null;
+  completed_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+}
+
+// ── Progress Updates (migration 005) ─────────────────────────────────────────
+
+export type UpdateType =
+  | 'status_change'
+  | 'photo_submitted'
+  | 'gps_ping'
+  | 'survival_check'
+  | 'note';
+
+export interface ProgressUpdateRow {
+  id: number;
+  tree_id: number;
+  paging_token: string;
+  update_type: UpdateType;
+  from_status: TreeStatus | null;
+  to_status: TreeStatus | null;
+  lat: string | null;
+  lng: string | null;
+  media_url: string | null;
+  ipfs_cid: string | null;
+  metadata: Record<string, unknown>;
+  submitted_by: string | null;
+  created_at: Date;
+}
+
+// ── Disputes (migration 006) ──────────────────────────────────────────────────
+
+export type DisputeStatus =
+  | 'open'
+  | 'under_review'
+  | 'resolved'
+  | 'escalated'
+  | 'closed';
+
+export type DisputeCategory =
+  | 'planting_fraud'
+  | 'survival_failure'
+  | 'escrow_release'
+  | 'gps_mismatch'
+  | 'admin_error'
+  | 'other';
+
+export interface DisputeRow {
+  id: number;
+  tree_id: number;
+  raised_by: string;
+  category: DisputeCategory;
+  description: string;
+  evidence_url: string | null;
+  evidence_ipfs_cid: string | null;
+  status: DisputeStatus;
+  assigned_to: string | null;
+  resolution_notes: string | null;
+  resolution_tx_hash: string | null;
+  created_at: Date;
+  updated_at: Date;
+  resolved_at: Date | null;
+}
+
+// ── Joined view type (common API response shape) ──────────────────────────────
+
+/** Convenience type: tree row joined with planter display name and species. */
+export interface TreeWithDetails extends TreeRow {
+  planter_name: string | null;
+  planter_stellar: string | null;
+  species_name: string | null;
+  co2_kg_per_year: string | null;
+}


### PR DESCRIPTION
Closes #546

## Summary
Designs and delivers the off-chain PostgreSQL schema for storing indexed contract events, cached tree records, and planter metadata across four reversible migrations with explicit index definitions, a rollback script, local seed data, and TypeScript row types.

## Migrations

### 003 - planters
Stores farmer metadata keyed on Stellar address. Soft-deleted via `deleted_at`. KYC status is a CHECK-constrained enum (pending/verified/rejected/suspended). Indexed on address, country, kyc_status, and active-only partial index.

### 004 - trees
Caches on-chain tree records keyed on `(contract_address, token_id)` for idempotent re-indexing - prevents duplicate rows on indexer restarts. Soft-deleted via `deleted_at`. FKs to planters and species_catalogue. Status enum mirrors contract state. Indexes cover all REST API filter/sort patterns.

### 005 - progress_updates
High-volume event log for status changes, photo submissions, GPS pings, survival checks, and admin notes. `paging_token` (Horizon operation paging token) is a UNIQUE idempotency key preventing duplicate event ingestion. Primary index on `(tree_id, created_at DESC)` for efficient timeline pagination. Partial index on survival_check rows for operational monitoring.

### 006 - disputes
Full dispute workflow with typed PostgreSQL ENUMs for status (open?under_review?resolved|escalated?closed) and category (planting_fraud/survival_failure/escrow_release/gps_mismatch/admin_error/other). Indexed for open-dispute dashboards and per-tree lookups.

## Other Files
- `db/migrations/003-006_rollback.sql` - drops all four tables + enums in dependency order
- `db/seeds/seed_trees_planters.sql` - 5 planters, 6 trees, 4 progress updates, 2 disputes; all idempotent via ON CONFLICT DO NOTHING
- `lib/db/schema.ts` - TypeScript row interfaces matching every column, ready for `getPool().query()`n
## Design Decisions
- No ORM sync - raw SQL migrations with explicit index definitions give full control and reviewability
- Soft delete on trees and planters preserves historical planting records and audit trail
- `(contract_address, token_id)` natural key on trees enables safe idempotent indexing from Horizon
- `dispute_status` and `dispute_category` as PostgreSQL ENUMs catch invalid state transitions at the DB layer
- Seed data uses real Stellar address format so it works immediately with the existing API layer

GPG-signed commit by modrispath@gmail.com - key B8383CA8D0860D62