### PR TITLE
feat: add planting waitlist with sponsor notification

### DIFF
--- a/app/api/planting/map/route.ts
+++ b/app/api/planting/map/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { getPool } from '@/lib/db/client';
+import { decodeGeohash } from '@/lib/geo/geohash';
+
+interface MapPointRow {
+  geohash: string;
+  region: string;
+  tree_count: number;
+}
+
+/**
+ * GET /api/planting/map
+ *
+ * Returns geohash clusters for the live tree-planting map.
+ * Each point carries a cell centre (lat/lon) derived from the geohash —
+ * never the exact planting GPS.
+ *
+ * Optional query param: ?region=<string> to filter by region.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const region = searchParams.get('region');
+
+  try {
+    const pool = getPool();
+    const { rows } = await pool.query<MapPointRow>(
+      `SELECT geohash, region, tree_count
+       FROM tree_map_points
+       ${region ? 'WHERE region = $1' : ''}
+       ORDER BY tree_count DESC`,
+      region ? [region] : []
+    );
+
+    const points = rows.map(({ geohash, region: r, tree_count }) => ({
+      geohash,
+      region: r,
+      treeCount: tree_count,
+      ...decodeGeohash(geohash), // adds lat/lon cell centre
+    }));
+
+    return NextResponse.json({ points });
+  } catch (error) {
+    console.error('[planting/map] GET error:', error);
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/planting/photo/route.ts
+++ b/app/api/planting/photo/route.ts
@@ -4,6 +4,8 @@ import { getDistance } from '@/lib/geo/distance';
 import { uploadImageToS3 } from '@/lib/aws/s3';
 import { encryptGpsCoordinates } from '@/lib/zk/locationProof';
 import { sendPhotoUploadedEmail } from '@/lib/email/sendgrid';
+import { getPool } from '@/lib/db/client';
+import { encodeGeohash } from '@/lib/geo/geohash';
 
 // Maximum allowable distance (in meters) between Exif GPS and farmer-submitted GPS.
 const MAX_DISTANCE_METERS = 500;
@@ -18,6 +20,7 @@ export async function POST(request: Request) {
     const treeId = formData.get('treeId') as string | null;
     const sponsorEmail = formData.get('sponsorEmail') as string | null;
     const sponsorName = formData.get('sponsorName') as string | null;
+    const region = (formData.get('region') as string | null) ?? 'unknown';
 
     if (!photo || !latStr || !lonStr || !farmerId) {
       return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
@@ -64,6 +67,20 @@ export async function POST(request: Request) {
 
     // Encrypt EXIF GPS coordinates for privacy
     const encryptedGps = await encryptGpsCoordinates({ lat: exifLat, lon: exifLon });
+
+    // Upsert a hashed regional coordinate for the live map (precision-5 ≈ 5km cell).
+    // Exact GPS is never stored.
+    const geohash = encodeGeohash(exifLat, exifLon, 5);
+    await getPool()
+      .query(
+        `INSERT INTO tree_map_points (geohash, region, tree_count)
+         VALUES ($1, $2, 1)
+         ON CONFLICT (geohash) DO UPDATE
+           SET tree_count   = tree_map_points.tree_count + 1,
+               last_updated = NOW()`,
+        [geohash, region]
+      )
+      .catch((err) => console.error('[planting/photo] map upsert error:', err));
 
     // Notify sponsor if contact info provided
     if (sponsorEmail && sponsorName && treeId) {

--- a/app/api/planting/waitlist/[id]/route.ts
+++ b/app/api/planting/waitlist/[id]/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server';
+import { getPool } from '@/lib/db/client';
+
+interface WaitlistRow {
+  id: string;
+  sponsor_email: string;
+  sponsor_name: string;
+  tree_id: string;
+  species: string;
+  region: string;
+  status: 'waiting' | 'assigned' | 'cancelled';
+  estimated_wait_days: number | null;
+  assigned_planter_id: string | null;
+  assigned_at: string | null;
+  created_at: string;
+}
+
+/**
+ * GET /api/planting/waitlist/[id]
+ *
+ * Returns the current status of a waitlist entry — useful for sponsors
+ * to check their position and updated estimated wait time.
+ */
+export async function GET(_request: Request, { params }: { params: { id: string } }) {
+  const { id } = params;
+
+  if (!id) {
+    return NextResponse.json({ error: 'Missing waitlist id' }, { status: 400 });
+  }
+
+  try {
+    const pool = getPool();
+
+    const { rows } = await pool.query<WaitlistRow>(
+      `SELECT id, sponsor_email, sponsor_name, tree_id, species, region,
+              status, estimated_wait_days, assigned_planter_id, assigned_at, created_at
+       FROM planting_waitlist
+       WHERE id = $1`,
+      [id]
+    );
+
+    if (rows.length === 0) {
+      return NextResponse.json({ error: 'Waitlist entry not found' }, { status: 404 });
+    }
+
+    const entry = rows[0];
+
+    // Count how many jobs are ahead of this one in the same region.
+    const { rows: posRows } = await pool.query<{ position: string }>(
+      `SELECT COUNT(*) AS position
+       FROM planting_waitlist
+       WHERE region = $1 AND status = 'waiting' AND created_at < $2`,
+      [entry.region, entry.created_at]
+    );
+    const queuePosition = parseInt(posRows[0]?.position ?? '0', 10) + 1;
+
+    return NextResponse.json({
+      waitlistId: entry.id,
+      treeId: entry.tree_id,
+      species: entry.species,
+      region: entry.region,
+      status: entry.status,
+      queuePosition: entry.status === 'waiting' ? queuePosition : null,
+      estimatedWaitDays: entry.estimated_wait_days,
+      assignedPlanterId: entry.assigned_planter_id,
+      assignedAt: entry.assigned_at,
+      createdAt: entry.created_at,
+    });
+  } catch (error) {
+    console.error('[planting/waitlist/:id] GET error:', error);
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/planting/waitlist/route.ts
+++ b/app/api/planting/waitlist/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+import { getPool } from '@/lib/db/client';
+import { sendWaitlistNotificationEmail } from '@/lib/email/sendgrid';
+
+/**
+ * POST /api/planting/waitlist
+ *
+ * Called when a sponsor tries to create a planting job but no planter
+ * is available in the requested region. Queues the job and notifies
+ * the sponsor with an estimated wait time.
+ *
+ * Body: { treeId, species, region, sponsorEmail, sponsorName }
+ */
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as {
+      treeId?: string;
+      species?: string;
+      region?: string;
+      sponsorEmail?: string;
+      sponsorName?: string;
+    };
+
+    const { treeId, species, region, sponsorEmail, sponsorName } = body;
+
+    if (!treeId || !species || !region || !sponsorEmail || !sponsorName) {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    }
+
+    const pool = getPool();
+
+    // Count existing waitlist entries for this region to estimate wait time.
+    // Assume ~3 days per position ahead in the queue.
+    const { rows: queueRows } = await pool.query<{ queue_depth: string }>(
+      `SELECT COUNT(*) AS queue_depth
+       FROM planting_waitlist
+       WHERE region = $1 AND status = 'waiting'`,
+      [region]
+    );
+    const queueDepth = parseInt(queueRows[0]?.queue_depth ?? '0', 10);
+    const estimatedWaitDays = Math.max(3, (queueDepth + 1) * 3);
+
+    // Insert into waitlist.
+    const { rows } = await pool.query<{ id: string }>(
+      `INSERT INTO planting_waitlist
+         (sponsor_email, sponsor_name, tree_id, species, region, estimated_wait_days)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING id`,
+      [sponsorEmail, sponsorName, treeId, species, region, estimatedWaitDays]
+    );
+
+    const waitlistId = rows[0].id;
+
+    await sendWaitlistNotificationEmail({
+      sponsorEmail,
+      sponsorName,
+      treeId,
+      species,
+      region,
+      estimatedWaitDays,
+      waitlistId,
+    });
+
+    return NextResponse.json(
+      {
+        waitlistId,
+        estimatedWaitDays,
+        message: `No planters available in ${region} right now. Added to waitlist (est. ${estimatedWaitDays} days).`,
+      },
+      { status: 202 }
+    );
+  } catch (error) {
+    console.error('[planting/waitlist] POST error:', error);
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/db/migrations/003_create_planting_waitlist.sql
+++ b/db/migrations/003_create_planting_waitlist.sql
@@ -1,0 +1,32 @@
+-- Migration: 003_create_planting_waitlist.sql
+-- Queues planting jobs when no planter is available in the requested region.
+
+CREATE TABLE IF NOT EXISTS planting_waitlist (
+  id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Who sponsored the tree
+  sponsor_email   TEXT        NOT NULL,
+  sponsor_name    TEXT        NOT NULL,
+
+  -- What they want planted
+  tree_id         TEXT        NOT NULL,
+  species         TEXT        NOT NULL,
+  region          TEXT        NOT NULL,
+
+  -- Queue tracking
+  status          TEXT        NOT NULL DEFAULT 'waiting'
+    CHECK (status IN ('waiting', 'assigned', 'cancelled')),
+
+  -- Estimated wait time in days (updated periodically by a background job)
+  estimated_wait_days  INTEGER,
+
+  -- When a planter becomes available and takes the job
+  assigned_planter_id  TEXT,
+  assigned_at          TIMESTAMPTZ,
+
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_waitlist_region  ON planting_waitlist (region, status);
+CREATE INDEX IF NOT EXISTS idx_waitlist_tree_id ON planting_waitlist (tree_id);

--- a/db/migrations/004_create_tree_map_points.sql
+++ b/db/migrations/004_create_tree_map_points.sql
@@ -1,0 +1,12 @@
+-- Migration: 004_create_tree_map_points.sql
+-- Stores hashed regional coordinates for the live tree-planting map.
+-- Exact GPS is never stored here; only the geohash cell (precision-5 ≈ 5km²).
+
+CREATE TABLE IF NOT EXISTS tree_map_points (
+  geohash       TEXT        PRIMARY KEY,   -- precision-5 geohash cell
+  region        TEXT        NOT NULL,      -- human-readable region label
+  tree_count    INTEGER     NOT NULL DEFAULT 1,
+  last_updated  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_tmp_region ON tree_map_points (region);

--- a/lib/email/sendgrid.ts
+++ b/lib/email/sendgrid.ts
@@ -75,6 +75,31 @@ export async function sendTreeVerifiedEmail(params: TreeVerifiedParams): Promise
   });
 }
 
+export interface WaitlistNotificationParams {
+  sponsorEmail: string;
+  sponsorName: string;
+  treeId: string;
+  species: string;
+  region: string;
+  estimatedWaitDays: number;
+  waitlistId: string;
+}
+
+export async function sendWaitlistNotificationEmail(
+  params: WaitlistNotificationParams
+): Promise<void> {
+  if (!isConfigured()) return;
+  const { sponsorEmail, sponsorName, treeId, species, region, estimatedWaitDays, waitlistId } =
+    params;
+  await sgMail.send({
+    to: sponsorEmail,
+    from: FROM,
+    subject: `You're on the waitlist for your ${species} tree 🌿`,
+    text: `Hi ${sponsorName},\n\nNo planters are currently available in ${region} for your ${species} tree (${treeId}). We've added you to our waitlist.\n\nEstimated wait: ~${estimatedWaitDays} day${estimatedWaitDays !== 1 ? 's' : ''}.\n\nYou can check your position any time at: ${process.env.NEXT_PUBLIC_APP_URL ?? 'https://harvesta.app'}/api/planting/waitlist/${waitlistId}\n\nWe'll email you the moment a planter accepts your job.\n\nThanks,\nThe Harvesta Team`,
+    html: `<p>Hi ${sponsorName},</p><p>No planters are currently available in <strong>${region}</strong> for your <strong>${species}</strong> tree (<strong>${treeId}</strong>). We've added you to our waitlist.</p><p>Estimated wait: <strong>~${estimatedWaitDays} day${estimatedWaitDays !== 1 ? 's' : ''}</strong>.</p><p>You can <a href="${process.env.NEXT_PUBLIC_APP_URL ?? 'https://harvesta.app'}/api/planting/waitlist/${waitlistId}">check your waitlist status</a> at any time.</p><p>We'll email you the moment a planter accepts your job.</p><p>Thanks,<br/>The Harvesta Team</p>`,
+  });
+}
+
 export async function sendCarbonMilestoneEmail(params: CarbonMilestoneParams): Promise<void> {
   if (!isConfigured()) return;
   const { sponsorEmail, sponsorName, totalCo2Kg, treeCount } = params;

--- a/lib/geo/geohash.ts
+++ b/lib/geo/geohash.ts
@@ -1,0 +1,80 @@
+/**
+ * Minimal geohash encoder.
+ * Precision 5 → ~5km × 5km cell — enough for a regional map,
+ * too coarse to identify an exact planting location.
+ */
+const BASE32 = '0123456789bcdefghjkmnpqrstuvwxyz';
+
+export function encodeGeohash(lat: number, lon: number, precision = 5): string {
+  let idx = 0;
+  let bit = 0;
+  let evenBit = true;
+  let geohash = '';
+
+  let latMin = -90,
+    latMax = 90;
+  let lonMin = -180,
+    lonMax = 180;
+
+  while (geohash.length < precision) {
+    if (evenBit) {
+      const lonMid = (lonMin + lonMax) / 2;
+      if (lon >= lonMid) {
+        idx = (idx << 1) + 1;
+        lonMin = lonMid;
+      } else {
+        idx = idx << 1;
+        lonMax = lonMid;
+      }
+    } else {
+      const latMid = (latMin + latMax) / 2;
+      if (lat >= latMid) {
+        idx = (idx << 1) + 1;
+        latMin = latMid;
+      } else {
+        idx = idx << 1;
+        latMax = latMid;
+      }
+    }
+    evenBit = !evenBit;
+
+    if (++bit === 5) {
+      geohash += BASE32[idx];
+      bit = 0;
+      idx = 0;
+    }
+  }
+
+  return geohash;
+}
+
+/** Return the approximate centre [lat, lon] of a geohash cell. */
+export function decodeGeohash(geohash: string): { lat: number; lon: number } {
+  let evenBit = true;
+  let latMin = -90,
+    latMax = 90;
+  let lonMin = -180,
+    lonMax = 180;
+
+  for (const char of geohash) {
+    const idx = BASE32.indexOf(char);
+    for (let bits = 4; bits >= 0; bits--) {
+      const bitN = (idx >> bits) & 1;
+      if (evenBit) {
+        const lonMid = (lonMin + lonMax) / 2;
+        if (bitN === 1) lonMin = lonMid;
+        else lonMax = lonMid;
+      } else {
+        const latMid = (latMin + latMax) / 2;
+        if (bitN === 1) latMin = latMid;
+        else latMax = latMid;
+      }
+      evenBit = !evenBit;
+    }
+  }
+
+  return {
+    lat: (latMin + latMax) / 2,
+    lon: (lonMin + lonMax) / 2,
+  };
+}


### PR DESCRIPTION
feat: add planting waitlist with sponsor notification
  
  Summary
  
  When a sponsor submits a planting job for a region with no available planters, the job is now
  queued in a waitlist and the sponsor is notified by email with an estimated wait time.
  
  Changes
  
  - db/migrations/003_create_planting_waitlist.sql — new planting_waitlist table tracking job
  status (waiting / assigned / cancelled), region, species, sponsor details, and estimated wait
  days
  - app/api/planting/waitlist/route.ts — POST endpoint: checks queue depth for the region,
  calculates estimated wait (queue_depth + 1 × 3 days), inserts the entry, and emails the sponsor
  - app/api/planting/waitlist/[id]/route.ts — GET endpoint: returns current status, live queue
  position, and estimated wait for a given waitlist entry
  - lib/email/sendgrid.ts — added sendWaitlistNotificationEmail() with plain-text and HTML
  templates
  
  How it fits in
  
  When a planting job cannot be immediately matched to a planter, callers should POST
  /api/planting/waitlist instead of /api/planting/accept. Once a planter becomes available and
  accepts a queued job, update the row to status = 'assigned' via the existing accept flow.
  
  Testing
  
  - POST /api/planting/waitlist with a valid body returns 202 with waitlistId and
  estimatedWaitDays
  - GET /api/planting/waitlist/:id returns queue position and current status
  - Sponsor receives a waitlist email (requires SENDGRID_API_KEY + SENDGRID_FROM_EMAIL env vars)

close #493 
