### PR TITLE
fix: cache GPS map queries with Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,10 @@ JWT_SECRET=replace-with-a-strong-random-secret-at-least-32-chars
 # Comma-separated list of IPs to block at the API gateway (no spaces).
 BLOCKED_IPS=
 
+# ─── Redis Cache ──────────────────────────────────────────────────────────────
+# Optional Redis connection string for shared GPS map query caching.
+REDIS_URL=
+
 # ─── Event Indexer ────────────────────────────────────────────────────────────
 # Comma-separated Soroban contract IDs to watch for TreeMinted, ProgressSubmitted,
 # and FundsReleased events. Leave blank to index all contracts.

--- a/app/api/map/regions/route.ts
+++ b/app/api/map/regions/route.ts
@@ -1,4 +1,10 @@
 import { NextResponse } from 'next/server';
+import {
+  MAP_REGIONS_CACHE_KEY,
+  getCachedMapData,
+  setCachedMapData,
+  type RegionMarker,
+} from '@/lib/cache/map-cache';
 import { getPool } from '@/lib/db/client';
 
 /**
@@ -22,6 +28,14 @@ export const runtime = 'nodejs';
 
 export async function GET() {
   try {
+    const cachedRegions = await getCachedMapData<RegionMarker[]>(MAP_REGIONS_CACHE_KEY);
+    if (cachedRegions) {
+      return NextResponse.json(
+        { regions: cachedRegions },
+        { headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=300' } }
+      );
+    }
+
     const pool = getPool();
 
     const { rows } = await pool.query<{
@@ -50,9 +64,11 @@ export async function GET() {
       farmers: parseInt(r.farmers, 10),
     }));
 
+    await setCachedMapData(MAP_REGIONS_CACHE_KEY, regions);
+
     return NextResponse.json(
       { regions },
-      { headers: { 'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=120' } }
+      { headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=300' } }
     );
   } catch (error) {
     // If the table doesn't exist yet return an empty list so the map still renders

--- a/app/api/planting/map/route.ts
+++ b/app/api/planting/map/route.ts
@@ -1,4 +1,10 @@
 import { NextResponse } from 'next/server';
+import {
+  getCachedMapData,
+  getPlantingMapCacheKey,
+  setCachedMapData,
+  type PlantingMapPoint,
+} from '@/lib/cache/map-cache';
 import { getPool } from '@/lib/db/client';
 import { decodeGeohash } from '@/lib/geo/geohash';
 
@@ -22,6 +28,15 @@ export async function GET(request: Request) {
   const region = searchParams.get('region');
 
   try {
+    const cacheKey = getPlantingMapCacheKey(region);
+    const cachedPoints = await getCachedMapData<PlantingMapPoint[]>(cacheKey);
+    if (cachedPoints) {
+      return NextResponse.json(
+        { points: cachedPoints },
+        { headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=300' } }
+      );
+    }
+
     const pool = getPool();
     const { rows } = await pool.query<MapPointRow>(
       `SELECT geohash, region, tree_count
@@ -38,7 +53,12 @@ export async function GET(request: Request) {
       ...decodeGeohash(geohash), // adds lat/lon cell centre
     }));
 
-    return NextResponse.json({ points });
+    await setCachedMapData(cacheKey, points);
+
+    return NextResponse.json(
+      { points },
+      { headers: { 'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=300' } }
+    );
   } catch (error) {
     console.error('[planting/map] GET error:', error);
     const message = error instanceof Error ? error.message : 'Internal server error';

--- a/app/api/planting/photo/route.ts
+++ b/app/api/planting/photo/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import exifr from 'exifr';
 import { getDistance } from '@/lib/geo/distance';
 import { uploadImageToS3 } from '@/lib/aws/s3';
+import { invalidateMapCoordinateCache } from '@/lib/cache/map-cache';
 import { encryptGpsCoordinates } from '@/lib/zk/locationProof';
 import { sendPhotoUploadedEmail } from '@/lib/email/sendgrid';
 import { getPool } from '@/lib/db/client';
@@ -96,6 +97,8 @@ export async function POST(request: Request) {
         [geohash, region]
       )
       .catch((err) => console.error('[planting/photo] map upsert error:', err));
+
+    await invalidateMapCoordinateCache();
 
     // Notify sponsor if contact info provided
     if (sponsorEmail && sponsorName && treeId) {

--- a/lib/cache/__tests__/map-cache.test.ts
+++ b/lib/cache/__tests__/map-cache.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createClient } from 'redis';
+import {
+  MAP_CACHE_TTL_SECONDS,
+  MAP_REGIONS_CACHE_KEY,
+  getCachedMapData,
+  getPlantingMapCacheKey,
+  invalidateMapCoordinateCache,
+  setCachedMapData,
+} from '@/lib/cache/map-cache';
+
+vi.mock('redis', () => ({
+  createClient: vi.fn(),
+}));
+
+const redisClient = {
+  isOpen: true,
+  connect: vi.fn(),
+  get: vi.fn(),
+  set: vi.fn(),
+  del: vi.fn(),
+  keys: vi.fn(),
+  on: vi.fn(),
+};
+
+describe('map-cache', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.REDIS_URL = 'redis://localhost:6379';
+    vi.mocked(createClient).mockReturnValue(redisClient as never);
+    redisClient.connect.mockResolvedValue(redisClient as never);
+    redisClient.get.mockReset();
+    redisClient.set.mockReset();
+    redisClient.del.mockReset();
+    redisClient.keys.mockReset();
+    redisClient.on.mockReset();
+  });
+
+  it('builds stable planting map cache keys', () => {
+    expect(getPlantingMapCacheKey(null)).toBe('map:gps-coordinates:planting:all');
+    expect(getPlantingMapCacheKey('kano')).toBe('map:gps-coordinates:planting:kano');
+  });
+
+  it('stores map data with a five-minute TTL', async () => {
+    await setCachedMapData(MAP_REGIONS_CACHE_KEY, [{ regionKey: 'r1' }]);
+
+    expect(redisClient.set).toHaveBeenCalledWith(
+      MAP_REGIONS_CACHE_KEY,
+      JSON.stringify([{ regionKey: 'r1' }]),
+      { EX: MAP_CACHE_TTL_SECONDS }
+    );
+    expect(MAP_CACHE_TTL_SECONDS).toBe(300);
+  });
+
+  it('reads JSON map data from Redis', async () => {
+    redisClient.get.mockResolvedValue(JSON.stringify([{ geohash: 'abc', treeCount: 2 }]));
+
+    await expect(getCachedMapData('map:gps-coordinates:planting:all')).resolves.toEqual([
+      { geohash: 'abc', treeCount: 2 },
+    ]);
+  });
+
+  it('invalidates region and planting coordinate caches', async () => {
+    redisClient.keys.mockResolvedValue([
+      'map:gps-coordinates:planting:all',
+      'map:gps-coordinates:planting:kano',
+    ]);
+    redisClient.del.mockResolvedValue(1);
+
+    await invalidateMapCoordinateCache();
+
+    expect(redisClient.keys).toHaveBeenCalledWith('map:gps-coordinates:planting:*');
+    expect(redisClient.del).toHaveBeenCalledWith(MAP_REGIONS_CACHE_KEY);
+    expect(redisClient.del).toHaveBeenCalledWith([
+      'map:gps-coordinates:planting:all',
+      'map:gps-coordinates:planting:kano',
+    ]);
+  });
+
+  it('skips Redis work when REDIS_URL is not configured', async () => {
+    delete process.env.REDIS_URL;
+
+    await setCachedMapData(MAP_REGIONS_CACHE_KEY, []);
+    await invalidateMapCoordinateCache();
+
+    expect(createClient).not.toHaveBeenCalled();
+  });
+});

--- a/lib/cache/map-cache.ts
+++ b/lib/cache/map-cache.ts
@@ -1,0 +1,100 @@
+import { createClient, type RedisClientType } from 'redis';
+
+const MAP_CACHE_TTL_SECONDS = 300;
+const MAP_CACHE_KEY_PREFIX = 'map:gps-coordinates';
+const MAP_REGIONS_CACHE_KEY = `${MAP_CACHE_KEY_PREFIX}:regions`;
+const PLANTING_MAP_CACHE_KEY_PREFIX = `${MAP_CACHE_KEY_PREFIX}:planting`;
+const PLANTING_MAP_CACHE_KEY_PATTERN = `${PLANTING_MAP_CACHE_KEY_PREFIX}:*`;
+
+let redisClient: RedisClientType | null = null;
+let redisConnection: Promise<RedisClientType | null> | null = null;
+
+export interface RegionMarker {
+  regionKey: string;
+  lat: number;
+  lng: number;
+  treesPlanted: number;
+  farmers: number;
+}
+
+export interface PlantingMapPoint {
+  geohash: string;
+  region: string;
+  treeCount: number;
+  lat: number;
+  lon: number;
+}
+
+export function getPlantingMapCacheKey(region: string | null): string {
+  return `${PLANTING_MAP_CACHE_KEY_PREFIX}:${region ?? 'all'}`;
+}
+
+async function getRedisClient(): Promise<RedisClientType | null> {
+  if (!process.env.REDIS_URL) return null;
+
+  if (redisClient?.isOpen) return redisClient;
+
+  if (!redisConnection) {
+    const client = createClient({ url: process.env.REDIS_URL });
+    client.on('error', (err) => {
+      console.error('[map-cache] Redis error:', err);
+    });
+
+    redisConnection = client
+      .connect()
+      .then(() => {
+        redisClient = client as RedisClientType;
+        return redisClient;
+      })
+      .catch((err) => {
+        console.error('[map-cache] Redis connection failed:', err);
+        redisClient = null;
+        redisConnection = null;
+        return null;
+      });
+  }
+
+  const client = await redisConnection;
+  return client;
+}
+
+export async function getCachedMapData<T>(key: string): Promise<T | null> {
+  const client = await getRedisClient();
+  if (!client) return null;
+
+  try {
+    const cached = await client.get(key);
+    return cached ? (JSON.parse(cached) as T) : null;
+  } catch (err) {
+    console.error('[map-cache] read failed:', err);
+    return null;
+  }
+}
+
+export async function setCachedMapData<T>(key: string, value: T): Promise<void> {
+  const client = await getRedisClient();
+  if (!client) return;
+
+  try {
+    await client.set(key, JSON.stringify(value), { EX: MAP_CACHE_TTL_SECONDS });
+  } catch (err) {
+    console.error('[map-cache] write failed:', err);
+  }
+}
+
+export async function invalidateMapCoordinateCache(): Promise<void> {
+  const client = await getRedisClient();
+  if (!client) return;
+
+  try {
+    const plantingMapKeys = await client.keys(PLANTING_MAP_CACHE_KEY_PATTERN);
+    await Promise.all([
+      client.del(MAP_REGIONS_CACHE_KEY),
+      plantingMapKeys.length > 0 ? client.del(plantingMapKeys) : Promise.resolve(0),
+    ]);
+  } catch (err) {
+    console.error('[map-cache] invalidation failed:', err);
+  }
+}
+
+export { MAP_CACHE_TTL_SECONDS, MAP_REGIONS_CACHE_KEY };

--- a/lib/indexer/event-upsert.ts
+++ b/lib/indexer/event-upsert.ts
@@ -1,6 +1,9 @@
 import type { Pool } from 'pg';
+import { invalidateMapCoordinateCache } from '@/lib/cache/map-cache';
 
 export type ContractEventType = 'TreeMinted' | 'ProgressSubmitted' | 'FundsReleased' | 'other';
+
+const MAP_COORDINATE_EVENTS = new Set<ContractEventType>(['TreeMinted', 'ProgressSubmitted']);
 
 export interface ContractEventRow {
   id: string;
@@ -18,7 +21,7 @@ export interface ContractEventRow {
  * ON CONFLICT DO NOTHING — idempotent and safe to replay on restart.
  */
 export async function upsertContractEvent(pool: Pool, row: ContractEventRow): Promise<void> {
-  await pool.query(
+  const result = await pool.query(
     `INSERT INTO contract_events
        (id, ledger, ledger_closed_at, contract_id, event_type, topics_xdr, value_xdr, paging_token)
      VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
@@ -34,6 +37,10 @@ export async function upsertContractEvent(pool: Pool, row: ContractEventRow): Pr
       row.pagingToken,
     ]
   );
+
+  if ((result.rowCount ?? 0) > 0 && MAP_COORDINATE_EVENTS.has(row.eventType)) {
+    await invalidateMapCoordinateCache();
+  }
 }
 
 /** Returns the ledger to start streaming from (0 = beginning of retention window). */

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-icons": "^5.5.0",
     "react-leaflet": "^5.0.0",
     "recharts": "^3.8.1",
+    "redis": "^5.10.0",
     "snarkjs": "^0.7.5",
     "sonner": "^2.0.7",
     "stellar-sdk": "^13.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       recharts:
         specifier: ^3.8.1
         version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1)
+      redis:
+        specifier: ^5.10.0
+        version: 5.12.1
       snarkjs:
         specifier: ^0.7.5
         version: 0.7.6
@@ -2222,6 +2225,42 @@ packages:
   '@react-pdf/types@2.11.1':
     resolution: {integrity: sha512-i9xQgfaDU9QoeNnbp6rltXCWg1huEh195rpOuN8cE4BZ2FuLdQrsIcb2dhFF9aOxXf+XBA6LOSpIW051MDD/bw==}
 
+  '@redis/bloom@5.12.1':
+    resolution: {integrity: sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/client@5.12.1':
+    resolution: {integrity: sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@node-rs/xxhash': ^1.1.0
+      '@opentelemetry/api': '>=1 <2'
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@redis/json@5.12.1':
+    resolution: {integrity: sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/search@5.12.1':
+    resolution: {integrity: sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/time-series@5.12.1':
+    resolution: {integrity: sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
   '@reduxjs/toolkit@2.11.2':
     resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
     peerDependencies:
@@ -2584,6 +2623,7 @@ packages:
 
   '@stellar/stellar-base@11.0.1':
     resolution: {integrity: sha512-VQh+1KEtFjegD6spx08+lENt8tQOkQQQZoLtqExjpRXyWlqDhEe+bXMlBTYKDc5MIynHyD42RPEib27UG17trA==}
+    deprecated: This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.
 
   '@stellar/stellar-base@13.1.0':
     resolution: {integrity: sha512-90EArG+eCCEzDGj3OJNoCtwpWDwxjv+rs/RNPhvg4bulpjN/CSRj+Ys/SalRcfM4/WRC5/qAfjzmJBAuquWhkA==}
@@ -3349,6 +3389,10 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
@@ -5575,6 +5619,10 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redis@5.12.1:
+    resolution: {integrity: sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==}
+    engines: {node: '>= 18.19.0'}
 
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
@@ -8974,6 +9022,26 @@ snapshots:
       '@react-pdf/primitives': 4.3.0
       '@react-pdf/stylesheet': 6.2.1
 
+  '@redis/bloom@5.12.1(@redis/client@5.12.1)':
+    dependencies:
+      '@redis/client': 5.12.1
+
+  '@redis/client@5.12.1':
+    dependencies:
+      cluster-key-slot: 1.1.2
+
+  '@redis/json@5.12.1(@redis/client@5.12.1)':
+    dependencies:
+      '@redis/client': 5.12.1
+
+  '@redis/search@5.12.1(@redis/client@5.12.1)':
+    dependencies:
+      '@redis/client': 5.12.1
+
+  '@redis/time-series@5.12.1(@redis/client@5.12.1)':
+    dependencies:
+      '@redis/client': 5.12.1
+
   '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.3)(redux@5.0.1))(react@19.2.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -10223,6 +10291,8 @@ snapshots:
   clone@2.1.2: {}
 
   clsx@2.1.1: {}
+
+  cluster-key-slot@1.1.2: {}
 
   code-block-writer@13.0.3: {}
 
@@ -12559,6 +12629,17 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - redux
+
+  redis@5.12.1:
+    dependencies:
+      '@redis/bloom': 5.12.1(@redis/client@5.12.1)
+      '@redis/client': 5.12.1
+      '@redis/json': 5.12.1(@redis/client@5.12.1)
+      '@redis/search': 5.12.1(@redis/client@5.12.1)
+      '@redis/time-series': 5.12.1(@redis/client@5.12.1)
+    transitivePeerDependencies:
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
 
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:


### PR DESCRIPTION
## Summary
- add a Redis-backed 5-minute cache for GPS map coordinate aggregation endpoints
- invalidate map coordinate caches when planting uploads or tree verification events are processed
- document REDIS_URL and add focused cache helper tests

closes #669

## Verification
- pnpm typecheck
- pnpm vitest run lib/cache/__tests__/map-cache.test.ts
- pnpm exec eslint app/api/map/regions/route.ts app/api/planting/map/route.ts app/api/planting/photo/route.ts lib/cache/map-cache.ts lib/cache/__tests__/map-cache.test.ts lib/indexer/event-upsert.ts lib/indexer/event-worker.ts lib/oracle/oracle-client.ts lib/stellar/species-voting.ts