### PR TITLE
[Frontend] Implement Premium Glassmorphism Dark/Light Theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -63,6 +63,13 @@
   --color-stellar-purple: var(--stellar-purple);
   --color-stellar-cyan: var(--stellar-cyan);
   --color-stellar-green: var(--stellar-green);
+
+  /* Glassmorphism tokens */
+  --color-glass-surface: var(--glass-surface);
+  --color-glass-surface-hover: var(--glass-surface-hover);
+  --color-glass-border: var(--glass-border);
+  --color-glass-selected: var(--glass-selected-bg);
+  --color-glass-selected-border: var(--glass-selected-border);
 }
 
 /* ===== LIGHT THEME ===== */
@@ -96,9 +103,9 @@
   --secondary: #e8f7fc;
   --secondary-foreground: #0d0b21;
 
-  /* Muted */
+  /* Muted — WCAG AAA: 7:1+ on #ffffff */
   --muted: #f1f5f9;
-  --muted-foreground: #64748b;
+  --muted-foreground: #475569;
 
   /* Accent — Stellar Purple */
   --accent: #3e1bdb;
@@ -128,6 +135,15 @@
   --sidebar-accent-foreground: #0d0b21;
   --sidebar-border: #e2e8f0;
   --sidebar-ring: #14b6e7;
+
+  /* Glassmorphism — light */
+  --glass-surface: rgba(255, 255, 255, 0.72);
+  --glass-surface-hover: rgba(255, 255, 255, 0.88);
+  --glass-border: rgba(13, 11, 33, 0.1);
+  --glass-shadow: 0 8px 32px rgba(13, 11, 33, 0.08);
+  --glass-blur: 16px;
+  --glass-selected-bg: rgba(20, 182, 231, 0.14);
+  --glass-selected-border: rgba(20, 182, 231, 0.55);
 }
 
 /* ===== DARK THEME ===== */
@@ -159,9 +175,9 @@
   --secondary: #1e1b3a;
   --secondary-foreground: #f1f5f9;
 
-  /* Muted */
+  /* Muted — WCAG AAA: 7:1+ on #0d0b21 */
   --muted: #1e1b3a;
-  --muted-foreground: #94a3b8;
+  --muted-foreground: #cbd5e1;
 
   /* Accent — Stellar Purple (lighter for dark) */
   --accent: #6e56cf;
@@ -191,6 +207,15 @@
   --sidebar-accent-foreground: #f1f5f9;
   --sidebar-border: rgba(255, 255, 255, 0.1);
   --sidebar-ring: #14b6e7;
+
+  /* Glassmorphism — dark */
+  --glass-surface: rgba(20, 18, 48, 0.62);
+  --glass-surface-hover: rgba(30, 27, 58, 0.78);
+  --glass-border: rgba(255, 255, 255, 0.12);
+  --glass-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  --glass-blur: 16px;
+  --glass-selected-bg: rgba(20, 182, 231, 0.2);
+  --glass-selected-border: rgba(20, 182, 231, 0.65);
 }
 
 @layer base {
@@ -253,4 +278,21 @@ html.no-transitions *,
 html.no-transitions *::before,
 html.no-transitions *::after {
   transition: none !important;
+}
+
+/* ===== GLASSMORPHISM UTILITIES ===== */
+.glass-surface {
+  background: var(--glass-surface);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--glass-shadow);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+}
+
+.glass-surface-selected {
+  background: var(--glass-selected-bg);
+  border-color: var(--glass-selected-border);
+  box-shadow:
+    var(--glass-shadow),
+    0 0 0 1px var(--glass-selected-border);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -111,8 +111,11 @@ export default function RootLayout({
               try {
                 var stored = localStorage.getItem('theme');
                 var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-                var theme = stored === 'light' || stored === 'dark' ? stored : (prefersDark ? 'dark' : 'light');
-                document.documentElement.classList.toggle('dark', theme === 'dark');
+                var resolved = stored === 'light' ? 'light' : stored === 'dark' ? 'dark' : (prefersDark ? 'dark' : 'light');
+                document.documentElement.classList.toggle('dark', resolved === 'dark');
+                if (stored === 'light' || stored === 'dark' || stored === 'system') {
+                  document.documentElement.dataset.theme = stored;
+                }
                 document.documentElement.classList.add('no-transitions');
                 window.addEventListener('load', function() {
                   document.documentElement.classList.remove('no-transitions');

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/molecules/Card';
 import { cn } from '@/lib/utils';
 import { hasCompletedOnboardingTour, requestOnboardingTourRestart } from '@/lib/onboardingTour';
+import { PreferencesSection } from '@/components/organisms/settings/PreferencesSection';
 
 type TabId = 'profile' | 'notifications' | 'preferences' | 'danger';
 
@@ -43,13 +44,6 @@ function NotificationSection() {
   return (
     <div>
       <Text variant="muted">Notification settings coming soon.</Text>
-    </div>
-  );
-}
-function PreferencesSection() {
-  return (
-    <div>
-      <Text variant="muted">Preference settings coming soon.</Text>
     </div>
   );
 }

--- a/components/molecules/SettingsCard.tsx
+++ b/components/molecules/SettingsCard.tsx
@@ -5,7 +5,7 @@ type SettingsCardProps = {
   description?: string;
   children: React.ReactNode;
   className?: string;
-  variant?: 'default' | 'danger';
+  variant?: 'default' | 'danger' | 'glass';
 };
 
 export function SettingsCard({
@@ -18,8 +18,10 @@ export function SettingsCard({
   return (
     <div
       className={cn(
-        ' border bg-card p-6    border-slate-200 rounded-2xl  shadow-sm',
-        variant === 'danger' && 'border-destructive/30 bg-destructive/5',
+        'rounded-2xl p-6 shadow-sm',
+        variant === 'glass' && 'glass-surface',
+        variant === 'default' && 'border border-border bg-card',
+        variant === 'danger' && 'border border-destructive/30 bg-destructive/5',
         className
       )}
     >

--- a/components/molecules/ThemeSelector/ThemeSelector.tsx
+++ b/components/molecules/ThemeSelector/ThemeSelector.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { Monitor, Moon, Sun } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { Theme } from '@/types/settings';
+
+type ThemeOption = {
+  value: Theme;
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+  preview: React.ReactNode;
+};
+
+const THEME_OPTIONS: ThemeOption[] = [
+  {
+    value: 'light',
+    label: 'Light',
+    description: 'Bright, clean interface',
+    icon: <Sun className="h-4 w-4" aria-hidden="true" />,
+    preview: (
+      <div className="flex h-full w-full flex-col gap-1.5 rounded-md bg-white p-2">
+        <div className="h-2 w-2/3 rounded-sm bg-[#0d0b21]" />
+        <div className="h-1.5 w-full rounded-sm bg-[#e2e8f0]" />
+        <div className="h-1.5 w-4/5 rounded-sm bg-[#e2e8f0]" />
+        <div className="mt-auto h-3 w-1/2 rounded-sm bg-[#14b6e7]" />
+      </div>
+    ),
+  },
+  {
+    value: 'dark',
+    label: 'Dark',
+    description: 'Easy on the eyes at night',
+    icon: <Moon className="h-4 w-4" aria-hidden="true" />,
+    preview: (
+      <div className="flex h-full w-full flex-col gap-1.5 rounded-md bg-[#0d0b21] p-2">
+        <div className="h-2 w-2/3 rounded-sm bg-[#f1f5f9]" />
+        <div className="h-1.5 w-full rounded-sm bg-[#1e1b3a]" />
+        <div className="h-1.5 w-4/5 rounded-sm bg-[#1e1b3a]" />
+        <div className="mt-auto h-3 w-1/2 rounded-sm bg-[#14b6e7]" />
+      </div>
+    ),
+  },
+  {
+    value: 'system',
+    label: 'System',
+    description: 'Match your device settings',
+    icon: <Monitor className="h-4 w-4" aria-hidden="true" />,
+    preview: (
+      <div className="relative h-full w-full overflow-hidden rounded-md">
+        <div className="absolute inset-0 flex">
+          <div className="flex w-1/2 flex-col gap-1 bg-white p-1.5">
+            <div className="h-1.5 w-3/4 rounded-sm bg-[#0d0b21]" />
+            <div className="h-1 w-full rounded-sm bg-[#e2e8f0]" />
+          </div>
+          <div className="flex w-1/2 flex-col gap-1 bg-[#0d0b21] p-1.5">
+            <div className="h-1.5 w-3/4 rounded-sm bg-[#f1f5f9]" />
+            <div className="h-1 w-full rounded-sm bg-[#1e1b3a]" />
+          </div>
+        </div>
+      </div>
+    ),
+  },
+];
+
+export type ThemeSelectorProps = {
+  value: Theme;
+  onChange: (theme: Theme) => void;
+  className?: string;
+  label?: string;
+  description?: string;
+};
+
+export function ThemeSelector({
+  value,
+  onChange,
+  className,
+  label = 'Theme',
+  description = 'Choose how FarmCredit looks. Changes apply immediately and are saved to your browser.',
+}: ThemeSelectorProps) {
+  return (
+    <fieldset className={cn('space-y-3', className)}>
+      <legend className="text-sm font-medium text-foreground">{label}</legend>
+      {description && (
+        <p id="theme-selector-description" className="text-xs text-muted-foreground">
+          {description}
+        </p>
+      )}
+
+      <div
+        role="radiogroup"
+        aria-label={label}
+        aria-describedby={description ? 'theme-selector-description' : undefined}
+        className="grid grid-cols-1 gap-3 sm:grid-cols-3"
+      >
+        {THEME_OPTIONS.map((option) => {
+          const isSelected = value === option.value;
+
+          return (
+            <button
+              key={option.value}
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              aria-label={`${option.label} theme — ${option.description}`}
+              onClick={() => onChange(option.value)}
+              className={cn(
+                'group relative flex flex-col overflow-hidden rounded-xl p-3 text-left transition-all duration-200',
+                'glass-surface hover:bg-glass-surface-hover',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                isSelected && 'glass-surface-selected ring-2 ring-primary/40'
+              )}
+            >
+              <div
+                className="mb-3 h-16 w-full overflow-hidden rounded-lg border border-glass-border bg-background/50"
+                aria-hidden="true"
+              >
+                {option.preview}
+              </div>
+
+              <div className="flex items-center gap-2">
+                <span
+                  className={cn(
+                    'flex h-7 w-7 items-center justify-center rounded-full transition-colors',
+                    isSelected
+                      ? 'bg-primary text-primary-foreground'
+                      : 'bg-muted text-muted-foreground group-hover:text-foreground'
+                  )}
+                >
+                  {option.icon}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <span className="block text-sm font-semibold text-foreground">{option.label}</span>
+                  <span className="block truncate text-xs text-muted-foreground">
+                    {option.description}
+                  </span>
+                </div>
+              </div>
+
+              {isSelected && (
+                <span
+                  className="absolute right-2.5 top-2.5 flex h-5 w-5 items-center justify-center rounded-full bg-primary text-primary-foreground"
+                  aria-hidden="true"
+                >
+                  <svg viewBox="0 0 12 12" className="h-3 w-3 fill-current">
+                    <path d="M10.28 2.28a.75.75 0 0 1 0 1.06l-5.25 5.25a.75.75 0 0 1-1.06 0L1.72 6.34a.75.75 0 1 1 1.06-1.06l1.97 1.97 4.72-4.72a.75.75 0 0 1 1.06 0Z" />
+                  </svg>
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}
+
+ThemeSelector.displayName = 'ThemeSelector';

--- a/components/molecules/ThemeSelector/index.ts
+++ b/components/molecules/ThemeSelector/index.ts
@@ -1,0 +1,2 @@
+export { ThemeSelector } from './ThemeSelector';
+export type { ThemeSelectorProps } from './ThemeSelector';

--- a/components/organisms/Header/Header.tsx
+++ b/components/organisms/Header/Header.tsx
@@ -26,7 +26,7 @@ const NAV_LINKS = [
 export function Header(): JSX.Element {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
-  const { theme, toggle: toggleTheme } = useTheme();
+  const { resolvedTheme, toggle: toggleTheme } = useTheme();
 
   const pathname = usePathname();
   const { wallet, disconnect } = useWalletContext();
@@ -107,10 +107,10 @@ export function Header(): JSX.Element {
             <button
               type="button"
               onClick={toggleTheme}
-              aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+              aria-label={`Switch to ${resolvedTheme === 'dark' ? 'light' : 'dark'} mode`}
               className="inline-flex h-9 w-9 items-center justify-center rounded-full text-white/70 transition-colors hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stellar-blue"
             >
-              {theme === 'dark' ? (
+              {resolvedTheme === 'dark' ? (
                 <Sun className="h-4 w-4" aria-hidden="true" />
               ) : (
                 <Moon className="h-4 w-4" aria-hidden="true" />
@@ -168,10 +168,10 @@ export function Header(): JSX.Element {
             <button
               type="button"
               onClick={toggleTheme}
-              aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+              aria-label={`Switch to ${resolvedTheme === 'dark' ? 'light' : 'dark'} mode`}
               className="inline-flex h-9 w-9 items-center justify-center rounded-full text-white/70 transition-colors hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stellar-blue"
             >
-              {theme === 'dark' ? (
+              {resolvedTheme === 'dark' ? (
                 <Sun className="h-4 w-4" aria-hidden="true" />
               ) : (
                 <Moon className="h-4 w-4" aria-hidden="true" />

--- a/components/organisms/settings/PreferencesSection.tsx
+++ b/components/organisms/settings/PreferencesSection.tsx
@@ -2,8 +2,8 @@
 
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useState } from 'react';
-import { CheckCircle2, Loader2, Monitor, Moon, Sun } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { CheckCircle2, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import {
@@ -14,9 +14,9 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { SettingsCard } from '@/components/molecules/SettingsCard';
+import { ThemeSelector } from '@/components/molecules/ThemeSelector';
+import { useTheme } from '@/hooks/useTheme';
 import { preferencesSchema, type PreferencesFormData } from '@/schemas/settings.schema';
-import { cn } from '@/lib/utils';
-import type { Theme } from '@/types/settings';
 
 const LANGUAGES = [
   { value: 'en', label: 'English' },
@@ -34,45 +34,42 @@ const CURRENCIES = [
   { value: 'GHS', label: 'GHS — Ghanaian Cedi' },
 ] as const;
 
-type ThemeOption = {
-  value: Theme;
-  label: string;
-  icon: React.ReactNode;
-};
-
-const THEME_OPTIONS: ThemeOption[] = [
-  { value: 'light', label: 'Light', icon: <Sun className="h-4 w-4" /> },
-  { value: 'dark', label: 'Dark', icon: <Moon className="h-4 w-4" /> },
-  { value: 'system', label: 'System', icon: <Monitor className="h-4 w-4" /> },
-];
-
 export function PreferencesSection() {
   const [saved, setSaved] = useState(false);
+  const { theme, setTheme } = useTheme();
 
   const {
     handleSubmit,
     control,
+    setValue,
     formState: { isSubmitting },
   } = useForm<PreferencesFormData>({
     resolver: zodResolver(preferencesSchema),
     defaultValues: {
       language: 'en',
       currency: 'USD',
-      theme: 'system',
+      theme,
     },
   });
 
+  useEffect(() => {
+    setValue('theme', theme);
+  }, [theme, setValue]);
+
   const onSubmit = async (data: PreferencesFormData) => {
+    setTheme(data.theme);
     await new Promise((r) => setTimeout(r, 800));
-    console.log('Preferences saved:', data);
     setSaved(true);
     setTimeout(() => setSaved(false), 2500);
   };
 
   return (
-    <SettingsCard title="Preferences" description="Set your language, currency, and display theme.">
+    <SettingsCard
+      title="Preferences"
+      description="Set your language, currency, and display theme."
+      variant="glass"
+    >
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
-        {/* Language */}
         <div className="space-y-1.5">
           <Label htmlFor="language">Language</Label>
           <Controller
@@ -80,7 +77,7 @@ export function PreferencesSection() {
             control={control}
             render={({ field }) => (
               <Select value={field.value} onValueChange={field.onChange}>
-                <SelectTrigger id="language" className="w-full">
+                <SelectTrigger id="language" className="w-full glass-surface">
                   <SelectValue placeholder="Select language" />
                 </SelectTrigger>
                 <SelectContent>
@@ -95,7 +92,6 @@ export function PreferencesSection() {
           />
         </div>
 
-        {/* Currency */}
         <div className="space-y-1.5">
           <Label htmlFor="currency">Currency</Label>
           <Controller
@@ -103,7 +99,7 @@ export function PreferencesSection() {
             control={control}
             render={({ field }) => (
               <Select value={field.value} onValueChange={field.onChange}>
-                <SelectTrigger id="currency" className="w-full">
+                <SelectTrigger id="currency" className="w-full glass-surface">
                   <SelectValue placeholder="Select currency" />
                 </SelectTrigger>
                 <SelectContent>
@@ -118,37 +114,20 @@ export function PreferencesSection() {
           />
         </div>
 
-        {/* Theme toggle */}
-        <div className="space-y-2">
-          <Label>Theme</Label>
-          <Controller
-            name="theme"
-            control={control}
-            render={({ field }) => (
-              <div className="grid grid-cols-3 gap-2">
-                {THEME_OPTIONS.map((option) => (
-                  <button
-                    key={option.value}
-                    type="button"
-                    onClick={() => field.onChange(option.value)}
-                    className={cn(
-                      'flex items-center justify-center gap-2 rounded-lg border px-3 py-2.5 text-sm font-medium transition-all',
-                      field.value === option.value
-                        ? 'border-primary bg-primary/10 text-primary'
-                        : 'border-border text-muted-foreground hover:border-primary/40 hover:text-foreground'
-                    )}
-                  >
-                    {option.icon}
-                    {option.label}
-                  </button>
-                ))}
-              </div>
-            )}
-          />
-          <p className="text-xs text-muted-foreground">Theme change applies immediately.</p>
-        </div>
+        <Controller
+          name="theme"
+          control={control}
+          render={({ field }) => (
+            <ThemeSelector
+              value={field.value}
+              onChange={(next) => {
+                field.onChange(next);
+                setTheme(next);
+              }}
+            />
+          )}
+        />
 
-        {/* Submit */}
         <div className="flex items-center justify-end gap-3 pt-2">
           {saved && (
             <span className="flex items-center gap-1.5 text-sm text-stellar-green">

--- a/hooks/useTheme.ts
+++ b/hooks/useTheme.ts
@@ -1,29 +1,59 @@
-'use client'
-import { useState, useEffect } from 'react'
+'use client';
+
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
+import {
+  applyThemeToDocument,
+  getStoredTheme,
+  getSystemPrefersDark,
+  persistTheme,
+  resolveTheme,
+  type ResolvedTheme,
+} from '@/lib/theme';
+import type { Theme } from '@/types/settings';
+
+function subscribeToSystemTheme(onStoreChange: () => void): () => void {
+  const mq = window.matchMedia('(prefers-color-scheme: dark)');
+  mq.addEventListener('change', onStoreChange);
+  return () => mq.removeEventListener('change', onStoreChange);
+}
+
+function getSystemThemeSnapshot(): ResolvedTheme {
+  return getSystemPrefersDark() ? 'dark' : 'light';
+}
+
+function getServerThemeSnapshot(): ResolvedTheme {
+  return 'dark';
+}
 
 export function useTheme() {
-  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
-    if (typeof window === 'undefined') return 'dark'
-    const stored = localStorage.getItem('theme')
-    if (stored === 'light' || stored === 'dark') return stored
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
-  })
+  const [theme, setThemeState] = useState<Theme>(() => getStoredTheme());
+  const systemTheme = useSyncExternalStore(
+    subscribeToSystemTheme,
+    getSystemThemeSnapshot,
+    getServerThemeSnapshot
+  );
+
+  const resolvedTheme: ResolvedTheme =
+    theme === 'system' ? systemTheme : resolveTheme(theme, systemTheme === 'dark');
 
   useEffect(() => {
-    document.documentElement.classList.toggle('dark', theme === 'dark')
-    localStorage.setItem('theme', theme)
-  }, [theme])
+    applyThemeToDocument(theme);
+    persistTheme(theme);
+  }, [theme, systemTheme]);
 
-  useEffect(() => {
-    const stored = localStorage.getItem('theme')
-    if (stored) return
-    const mq = window.matchMedia('(prefers-color-scheme: dark)')
-    const handler = (e: MediaQueryListEvent) => setTheme(e.matches ? 'dark' : 'light')
-    mq.addEventListener('change', handler)
-    return () => mq.removeEventListener('change', handler)
-  }, [])
+  const setTheme = useCallback((next: Theme) => {
+    setThemeState(next);
+  }, []);
 
-  const toggle = () => setTheme(t => t === 'dark' ? 'light' : 'dark')
+  const toggle = useCallback(() => {
+    setThemeState(resolvedTheme === 'dark' ? 'light' : 'dark');
+  }, [resolvedTheme]);
 
-  return { theme, toggle, isDark: theme === 'dark' }
+  return {
+    theme,
+    resolvedTheme,
+    setTheme,
+    toggle,
+    isDark: resolvedTheme === 'dark',
+  };
 }

--- a/lib/__tests__/theme.test.ts
+++ b/lib/__tests__/theme.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { isTheme, resolveTheme } from '@/lib/theme';
+
+describe('lib/theme', () => {
+  describe('isTheme', () => {
+    it('accepts valid theme values', () => {
+      expect(isTheme('light')).toBe(true);
+      expect(isTheme('dark')).toBe(true);
+      expect(isTheme('system')).toBe(true);
+    });
+
+    it('rejects invalid values', () => {
+      expect(isTheme('auto')).toBe(false);
+      expect(isTheme(null)).toBe(false);
+      expect(isTheme(undefined)).toBe(false);
+    });
+  });
+
+  describe('resolveTheme', () => {
+    it('returns explicit light and dark themes', () => {
+      expect(resolveTheme('light', true)).toBe('light');
+      expect(resolveTheme('dark', false)).toBe('dark');
+    });
+
+    it('follows system preference for system theme', () => {
+      expect(resolveTheme('system', true)).toBe('dark');
+      expect(resolveTheme('system', false)).toBe('light');
+    });
+  });
+});

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,0 +1,39 @@
+import type { Theme } from '@/types/settings';
+
+export const THEME_STORAGE_KEY = 'theme';
+
+export type ResolvedTheme = 'light' | 'dark';
+
+const VALID_THEMES: Theme[] = ['light', 'dark', 'system'];
+
+export function isTheme(value: string | null | undefined): value is Theme {
+  return value === 'light' || value === 'dark' || value === 'system';
+}
+
+export function resolveTheme(theme: Theme, prefersDark = false): ResolvedTheme {
+  if (theme === 'light' || theme === 'dark') return theme;
+  return prefersDark ? 'dark' : 'light';
+}
+
+export function getSystemPrefersDark(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches;
+}
+
+export function getStoredTheme(): Theme {
+  if (typeof window === 'undefined') return 'system';
+  const stored = localStorage.getItem(THEME_STORAGE_KEY);
+  return isTheme(stored) ? stored : 'system';
+}
+
+export function applyThemeToDocument(theme: Theme): ResolvedTheme {
+  const resolved = resolveTheme(theme, getSystemPrefersDark());
+  document.documentElement.classList.toggle('dark', resolved === 'dark');
+  document.documentElement.dataset.theme = theme;
+  return resolved;
+}
+
+export function persistTheme(theme: Theme): void {
+  if (!VALID_THEMES.includes(theme)) return;
+  localStorage.setItem(THEME_STORAGE_KEY, theme);
+}


### PR DESCRIPTION
## Summary
- Add a premium glassmorphism ThemeSelector with light, dark, and system modes
- Extend useTheme with localStorage sync, system preference detection, and shared theme utilities
- Add glassmorphism CSS tokens and WCAG AAA contrast updates for muted text
- Wire PreferencesSection into Settings and update Header toggle to use resolvedTheme

Closes #659

## Test plan
- [ ] Open Settings > Preferences and verify ThemeSelector renders with glass cards
- [ ] Select Light, Dark, and System — UI updates immediately
- [ ] Refresh page — theme persists from localStorage
- [ ] With System selected, change OS theme — app follows
- [ ] Verify header sun/moon toggle reflects resolved theme
- [ ] Check muted text contrast in both modes