### PR TITLE
feat: add signed URL endpoint for certificate assets

### DIFF
--- a/app/api/certificate/secure-link/route.ts
+++ b/app/api/certificate/secure-link/route.ts
@@ -1,0 +1,52 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { verifyPlanterJwt } from '@/lib/auth/jwt';
+import { getSignedPrivateUrl } from '@/lib/aws/s3';
+
+export const runtime = 'nodejs';
+
+interface SecureLinkBody {
+  s3Key: string;
+  expiresIn?: number;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    // Get authorization header
+    const authHeader = request.headers.get('Authorization');
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return NextResponse.json(
+        { error: 'Authorization header with Bearer token is required' },
+        { status: 401 }
+      );
+    }
+
+    // Verify JWT
+    const token = authHeader.slice(7);
+    const payload = await verifyPlanterJwt(token);
+    if (!payload) {
+      return NextResponse.json({ error: 'Invalid or expired token' }, { status: 401 });
+    }
+
+    // Parse and validate request body
+    let body: Partial<SecureLinkBody>;
+    try {
+      body = (await request.json()) as Partial<SecureLinkBody>;
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    const { s3Key, expiresIn } = body;
+    if (!s3Key) {
+      return NextResponse.json({ error: 's3Key is required' }, { status: 400 });
+    }
+
+    // Generate signed URL
+    const signedUrl = await getSignedPrivateUrl(s3Key, expiresIn);
+
+    return NextResponse.json({ signedUrl });
+  } catch (error) {
+    console.error('[certificate/secure-link] error:', error);
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary

Build a secure metadata endpoint that generates temporary signed S3 URLs for accessing private certificate assets.

## Related Issue

<!-- Link to the issue this PR addresses -->

Closes #671 

## What Was Implemented

Successfully implemented the S3 Private Signed URL Generator for Certificates

- [ ]

## Implementation Details

- Created the API route at app/api/certificate/secure-link/route.ts
- Implemented session validation using verifyPlanterJwt from @/lib/auth/jwt
- Validated required parameters like s3Key and optional expiresIn
- Used the existing getSignedPrivateUrl function from @/lib/aws/s3 to generate the temporary signed URL
- Returned the signed URL in a JSON response

## Screenshots / Recordings

<!-- Required for any UI change. Before/after if modifying existing UI. -->

## How to Test

<!-- Step-by-step instructions for reviewers to verify the changes -->

1.
2.
3.

## Checklist

- [x] My code follows the atomic commit convention
- [x] Each commit message follows Conventional Commits (`feat:`, `fix:`, etc.)
- [x] I have performed a self-review of my code
- [x] My changes build successfully (`pnpm build`)
- [x] My changes pass linting (`pnpm lint`)
- [ ] I have added/updated relevant documentation
- [ ] New components follow the atomic design pattern (atoms → molecules → organisms)
- [ ] UI changes are responsive and tested on mobile viewports
- [ ] I have added screenshots/recordings for UI changes
