### PR TITLE
feat(i18n): add Hausa language support (EN/HA/FR) and footer language selector

### DIFF
--- a/components/organisms/Footer/Footer.tsx
+++ b/components/organisms/Footer/Footer.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { NewsletterForm } from '@/components/organisms/Footer/NewsletterForm';
+import { LanguageSelector } from '@/components/organisms/Header/LanguageSelector';
 import { FaXTwitter, FaGithub, FaDiscord } from 'react-icons/fa6';
 import { useAppTranslation } from '@/hooks/useTranslation';
 import type { TFunction } from 'i18next';
@@ -132,24 +133,28 @@ export function Footer(): React.ReactNode {
             {t('footer.copyright', { year: currentYear })}
           </p>
 
-          <ul className="flex gap-4">
-            {socialLinks.map((social) => {
-              const Icon = social.icon;
-              return (
-                <li key={social.label}>
-                  <Link
-                    href={social.href}
-                    target="_blank"
-                    aria-label={social.ariaLabel}
-                    className="flex items-center justify-center w-10 h-10 rounded-lg border border-cyan-500/20 text-stellar-blue hover:bg-cyan-500/10 hover:border-stellar-blue transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-stellar-blue"
-                  >
-                    <Icon className="w-5 h-5" />
-                    <span className="sr-only">{social.label}</span>
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
+          <div className="flex items-center gap-4">
+            <LanguageSelector variant="desktop" />
+
+            <ul className="flex gap-4">
+              {socialLinks.map((social) => {
+                const Icon = social.icon;
+                return (
+                  <li key={social.label}>
+                    <Link
+                      href={social.href}
+                      target="_blank"
+                      aria-label={social.ariaLabel}
+                      className="flex items-center justify-center w-10 h-10 rounded-lg border border-cyan-500/20 text-stellar-blue hover:bg-cyan-500/10 hover:border-stellar-blue transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-stellar-blue"
+                    >
+                      <Icon className="w-5 h-5" />
+                      <span className="sr-only">{social.label}</span>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
         </div>
       </div>
     </footer>

--- a/lib/i18n/config.ts
+++ b/lib/i18n/config.ts
@@ -5,14 +5,16 @@ import enTranslations from '@/lib/i18n/locales/en.json';
 import esTranslations from '@/lib/i18n/locales/es.json';
 import frTranslations from '@/lib/i18n/locales/fr.json';
 import ptTranslations from '@/lib/i18n/locales/pt.json';
+import haTranslations from '@/lib/i18n/locales/ha.json';
 
-export const SUPPORTED_LANGUAGES = ['en', 'es', 'fr', 'pt'] as const;
+export const SUPPORTED_LANGUAGES = ['en', 'ha', 'fr', 'es', 'pt'] as const;
 export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 
 export const LANGUAGE_LABELS: Record<SupportedLanguage, string> = {
   en: 'English',
-  es: 'Español',
+  ha: 'Hausa',
   fr: 'Français',
+  es: 'Español',
   pt: 'Português',
 };
 
@@ -26,8 +28,9 @@ export function isRTL(lang: string): boolean {
 const i18nConfig: InitOptions = {
   resources: {
     en: { translation: enTranslations },
-    es: { translation: esTranslations },
+    ha: { translation: haTranslations },
     fr: { translation: frTranslations },
+    es: { translation: esTranslations },
     pt: { translation: ptTranslations },
   },
   fallbackLng: 'en',

--- a/lib/i18n/locales/en.json
+++ b/lib/i18n/locales/en.json
@@ -91,6 +91,7 @@
     "en": "English",
     "es": "Spanish",
     "fr": "French",
-    "pt": "Portuguese"
+    "pt": "Portuguese",
+    "ha": "Hausa"
   }
 }

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -91,6 +91,7 @@
     "en": "Anglais",
     "es": "Espagnol",
     "fr": "Français",
-    "pt": "Portugais"
+    "pt": "Portugais",
+    "ha": "Haoussa"
   }
 }

--- a/lib/i18n/locales/ha.json
+++ b/lib/i18n/locales/ha.json
@@ -1,0 +1,97 @@
+{
+  "nav": {
+    "home": "Gida",
+    "blog": "Shafin Labarai",
+    "purchaseCredits": "Sayi Kiredi",
+    "dashboard": "Allon Sarrafa",
+    "projects": "Ayyuka",
+    "marketplace": "Kasuwa",
+    "transactions": "Ma'amaloli"
+  },
+  "header": {
+    "connectWallet": "Haɗa Jakar Kuɗi",
+    "openMenu": "Buɗe menu na kewayawa",
+    "languageSelector": "Zaɓi harshe"
+  },
+  "mobile": {
+    "closeMenu": "Rufe menu na kewayawa",
+    "tapToDisconnect": "Taɓa don yanke haɗin"
+  },
+  "footer": {
+    "stayUpdated": "Kasance Da Labarai",
+    "stayUpdatedDesc": "Samu sabuntawa na ƙarshe kan FarmCredit da hanyar sadarwa ta Stellar.",
+    "about": "Game Da",
+    "resources": "Albarkatu",
+    "legal": "Doka",
+    "aboutFarmCredit": "Game Da FarmCredit",
+    "blog": "Shafin Labarai",
+    "documentation": "Takaddun Bayanai",
+    "apiDocs": "Takaddun API",
+    "devGuide": "Jagoran Mai Haɓakawa",
+    "community": "Al'umma",
+    "terms": "Sharuɗɗan Sabis",
+    "privacy": "Manufar Sirri",
+    "cookies": "Manufar Cookie",
+    "copyright": "© {{year}} FarmCredit. Duk haƙƙin mallakar an kiyaye su.",
+    "followTwitter": "Bi mu a Twitter/X",
+    "viewGithub": "Duba ma'ajiyar GitHub ɗinmu",
+    "joinDiscord": "Shiga al'ummar Discord ɗinmu",
+    "twitter": "Twitter",
+    "github": "GitHub",
+    "discord": "Discord"
+  },
+  "newsletter": {
+    "emailPlaceholder": "Shigar da imel ɗinka",
+    "emailAriaLabel": "Adireshi na imel don rajista ta jaridar labarai",
+    "subscribe": "Yi Rajista",
+    "emailRequired": "Ana buƙatar imel",
+    "invalidEmail": "Da fatan za a shigar da adireshi na imel mai inganci",
+    "successMessage": "An yi rajistarka 🎉",
+    "errorMessage": "Wani abu ya faru. Sake gwadawa."
+  },
+  "blog": {
+    "pageTitle": "Shafin Labarai",
+    "pageSubtitle": "Ra'ayoyi kan kiredi na carbon, noma mai ɗorewa, fasahar yanayi, da manufar noma.",
+    "featuredBlogTitle": "Shafin Labarai na FarmCredit",
+    "categoryFiltersLabel": "Tacewas na nau'i",
+    "readPost": "Karanta labari: {{title}}",
+    "loadingAriaLabel": "Ana lodi labarai",
+    "errorTitle": "Wani abu ya faru",
+    "errorDesc": "Ba mu iya lodi labarain yanzu. Wannan na iya zama matsala ta wucin gadi — da fatan za a sake gwadawa.",
+    "errorReference": "Tunani kan kuskure: {{digest}}",
+    "tryAgain": "Sake gwadawa",
+    "tryAgainAriaLabel": "Sake gwada lodi shafin labarai"
+  },
+  "purchase": {
+    "nextButton": "Na gaba",
+    "nextAriaLabel": "Ci gaba zuwa haɗin jakar kuɗi",
+    "continueToPayment": "Ci gaba zuwa biyan kuɗi",
+    "loading": "Ana lodi...",
+    "compareTitle": "Kwatanta Ayyukan Kiredi na Carbon",
+    "compareSubtitle": "Zaɓi har zuwa ayyuka 3 don kwatanta fasali, farashi, da fa'idodi kusa da juna"
+  },
+  "home": {
+    "badge": "Yana aiki ta Stellar",
+    "title": "FarmCredit",
+    "subtitle": "Dandalin bashi na noma mai rarrabuwa da aka gina akan hanyar sadarwa ta Stellar.",
+    "totalCreditIssued": "Jimlar Kiredi Da Aka Bayar",
+    "activeFarmers": "Manoma Masu Aiki",
+    "repaymentRate": "Adadin Biyan Bashi",
+    "getStarted": "Fara",
+    "getStartedDescription": "Haɗa jakar kuɗin ka don samun damar ayyukan bashi na noma.",
+    "connectWallet": "Haɗa Jakar Kuɗi",
+    "readBlog": "Karanta Shafin Labarain Mu",
+    "purchaseCarbon": "Sayi Kiredi na Carbon",
+    "makeDonation": "Yi Gudummawa",
+    "showToast": "Nuna Saƙo",
+    "transactions": "Ma'amaloli",
+    "profileSaved": "An ajiye bayanan bayanai!"
+  },
+  "languages": {
+    "en": "Turanci",
+    "es": "Sifeniyanci",
+    "fr": "Faransanci",
+    "pt": "Fotigalanci",
+    "ha": "Hausa"
+  }
+}


### PR DESCRIPTION
Closes #667\n\n## Summary\n\nAdds Hausa (ha) as a supported language alongside the existing EN and FR, and places a language selector in the footer so users can switch locale from both the nav and the footer.\n\n## Files changed\n\n| File | Change |\n|---|---|\n| lib/i18n/locales/ha.json | New — full Hausa translations for all keys |\n| lib/i18n/config.ts | Add ha to SUPPORTED_LANGUAGES, LANGUAGE_LABELS, and i18nConfig resources |\n| lib/i18n/locales/en.json | Add ha: 'Hausa' to languages section |\n| lib/i18n/locales/fr.json | Add ha: 'Haoussa' to languages section |\n| components/organisms/Footer/Footer.tsx | Add LanguageSelector to bottom bar |\n\n## How it works\n\nThe i18n stack (i18next + react-i18next + i18next-browser-languagedetector) was already fully wired. Adding Hausa required:\n1. A complete ha.json translation file covering every key in the app\n2. Registering ha in the config so the detector and selector pick it up\n3. The selected locale is persisted to localStorage under armcredit-language (existing behaviour, no change needed)\n\nThe LanguageSelector component already existed in the Header. This PR reuses it verbatim in the Footer bottom bar.\n\n## Acceptance criteria\n- [x] Language selector on nav bar (already existed)\n- [x] Language selector on footer (added)\n- [x] Selected locale stored in localStorage (existing armcredit-language key)\n- [x] Hausa translations provided for all UI strings