### PR TITLE
feat(planter-registry): implement dynamic reputation scoring

### DIFF
--- a/contracts/planter-registry/src/lib.rs
+++ b/contracts/planter-registry/src/lib.rs
@@ -46,6 +46,11 @@ pub struct PlanterRecord {
     pub region: String,
     pub score: u32,
     pub registered_at: u64,
+    /// Cumulative sapling survival inputs used to derive `score`.
+    pub saplings_planted: u32,
+    pub saplings_survived: u32,
+    pub verifications_passed: u32,
+    pub verifications_total: u32,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -90,6 +95,10 @@ impl PlanterRegistry {
             region,
             score: INITIAL_SCORE,
             registered_at: env.ledger().timestamp(),
+            saplings_planted: 0,
+            saplings_survived: 0,
+            verifications_passed: 0,
+            verifications_total: 0,
         };
 
         env.storage()
@@ -152,6 +161,56 @@ impl PlanterRegistry {
 
         env.events().publish(
             (symbol_short!("ScoreSls"), wallet.clone()),
+            record.score,
+        );
+    }
+
+    /// Record a batch of sapling survival and oracle verification data, then
+    /// recompute the planter's reputation score from cumulative history.
+    ///
+    /// Score (0–100) is weighted: survival rate contributes 70 points and
+    /// verification success rate contributes 30 points.
+    ///
+    /// Only callable by the contract admin.
+    pub fn record_outcome(
+        env: Env,
+        wallet: Address,
+        new_planted: u32,
+        new_survived: u32,
+        verif_passed: u32,
+        verif_total: u32,
+    ) {
+        Self::require_admin(&env);
+
+        let key = Self::planter_key(&env, &wallet);
+        let mut record: PlanterRecord = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(&env, Error::NotRegistered));
+
+        record.saplings_planted = record.saplings_planted.saturating_add(new_planted);
+        record.saplings_survived = record.saplings_survived.saturating_add(new_survived);
+        record.verifications_passed = record.verifications_passed.saturating_add(verif_passed);
+        record.verifications_total = record.verifications_total.saturating_add(verif_total);
+
+        let survival_score = if record.saplings_planted == 0 {
+            0u32
+        } else {
+            record.saplings_survived.saturating_mul(70) / record.saplings_planted
+        };
+
+        let verification_score = if record.verifications_total == 0 {
+            0u32
+        } else {
+            record.verifications_passed.saturating_mul(30) / record.verifications_total
+        };
+
+        record.score = survival_score.saturating_add(verification_score);
+        env.storage().persistent().set(&key, &record);
+
+        env.events().publish(
+            (symbol_short!("ScoreUpd"), wallet.clone()),
             record.score,
         );
     }
@@ -335,5 +394,77 @@ mod tests {
     fn test_meets_min_score_unregistered_returns_false() {
         let (env, _, client) = setup();
         assert!(!client.meets_min_score(&Address::generate(&env), &0u32));
+    }
+
+    // ── record_outcome ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_record_outcome_perfect_scores_to_100() {
+        let (env, _, client) = setup();
+        let planter = Address::generate(&env);
+
+        client.register_planter(&planter, &name_hash(&env, 1), &String::from_str(&env, "s1"));
+        // 100 % survival, 100 % verification → 70 + 30 = 100
+        client.record_outcome(&planter, &100, &100, &50, &50);
+
+        let record = client.get_planter(&planter).unwrap();
+        assert_eq!(record.score, 100);
+        assert_eq!(record.saplings_planted, 100);
+        assert_eq!(record.saplings_survived, 100);
+        assert_eq!(record.verifications_passed, 50);
+        assert_eq!(record.verifications_total, 50);
+    }
+
+    #[test]
+    fn test_record_outcome_partial_rates() {
+        let (env, _, client) = setup();
+        let planter = Address::generate(&env);
+
+        client.register_planter(&planter, &name_hash(&env, 1), &String::from_str(&env, "s1"));
+        // 50 % survival → 35, 50 % verification → 15, total = 50
+        client.record_outcome(&planter, &100, &50, &10, &20);
+
+        let record = client.get_planter(&planter).unwrap();
+        assert_eq!(record.score, 50);
+    }
+
+    #[test]
+    fn test_record_outcome_accumulates_across_batches() {
+        let (env, _, client) = setup();
+        let planter = Address::generate(&env);
+
+        client.register_planter(&planter, &name_hash(&env, 1), &String::from_str(&env, "s1"));
+        // Batch 1: 100 planted, 50 survived; 10 verif, 10 total
+        client.record_outcome(&planter, &100, &50, &10, &10);
+        // Batch 2: 100 more planted, 100 survived; 10 verif, 10 total
+        // Cumulative: 200 planted, 150 survived (75 %), 20/20 verif (100 %)
+        // score = 150*70/200 + 20*30/20 = 52 + 30 = 82
+        client.record_outcome(&planter, &100, &100, &10, &10);
+
+        let record = client.get_planter(&planter).unwrap();
+        assert_eq!(record.saplings_planted, 200);
+        assert_eq!(record.saplings_survived, 150);
+        assert_eq!(record.score, 82);
+    }
+
+    #[test]
+    fn test_record_outcome_zero_verif_total_omits_verification() {
+        let (env, _, client) = setup();
+        let planter = Address::generate(&env);
+
+        client.register_planter(&planter, &name_hash(&env, 1), &String::from_str(&env, "s1"));
+        // No verification data — only survival contributes
+        client.record_outcome(&planter, &100, &80, &0, &0);
+
+        let record = client.get_planter(&planter).unwrap();
+        // 80 % survival → 56, 0 verification → 0, total = 56
+        assert_eq!(record.score, 56);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #4)")]
+    fn test_record_outcome_unregistered_panics() {
+        let (env, _, client) = setup();
+        client.record_outcome(&Address::generate(&env), &10, &10, &5, &5);
     }
 }


### PR DESCRIPTION
## Summary

Implements a dynamic reputation scoring mechanism in the `planter-registry` contract. A planter's score is recomputed from their full historical record each time a new batch of sapling survival and oracle verification data is submitted.

## Related Issue

Closes #636

## What Was Implemented
- [x] Added `saplings_planted`, `saplings_survived`, `verifications_passed`, and `verifications_total` fields to `PlanterRecord` to persist cumulative history on-chain
- [x] Added `record_outcome()` (admin-only) that accepts a batch of survival and verification data, accumulates it into the planter's lifetime totals, and recomputes `score` dynamically
- [x] Score formula (0–100): `survived * 70 / planted + verif_passed * 30 / verif_total` — weighted 70% survival, 30% verification; guards against division-by-zero for both components
- [x] Emits `ScoreUpd` event on every `record_outcome` call
- [x] All new fields zero-initialised on `register_planter`; existing `increment_score` / `slash_score` preserved for manual admin overrides

## Implementation Details

Score is derived entirely from cumulative on-chain history rather than flat increments/decrements, so it reflects the planter's lifetime track record. Integer arithmetic is used throughout (no floats in Soroban); both the survival and verification denominators are guarded with an explicit zero-check to avoid a panic. `saturating_add` / `saturating_mul` prevent overflow on large cumulative totals. The 70/30 weighting was chosen to prioritise on-the-ground outcomes over oracle verification pass rate.

## Screenshots / Recordings

N/A — contract only, no UI changes.

## How to Test

1. Deploy the contract and call `initialize(admin)`
2. Register a planter with `register_planter` — confirm `score == 100` and all new fields are `0`
3. Call `record_outcome(wallet, 100, 80, 10, 10)` — expect `score == 80*70/100 + 10*30/10 = 56 + 30 = 86`
4. Call `record_outcome` again with another batch and confirm the totals accumulate correctly before the score is recomputed
5. Call `record_outcome` with `verif_total == 0` — confirm only the survival component contributes
6. Run `cargo test -p planter-registry` — all 16 tests should pass

## Checklist

- [x] My code follows the atomic commit convention
- [x] Each commit message follows Conventional Commits (`feat:`, `fix:`, etc.)
- [x] I have performed a self-review of my code
- [ ] My changes build successfully (`pnpm build`)
- [ ] My changes pass linting (`pnpm lint`)
- [ ] I have added/updated relevant documentation
- [ ] New components follow the atomic design pattern (atoms → molecules → organisms)
- [ ] UI changes are responsive and tested on mobile viewports
- [ ] I have added screenshots/recordings for UI changes
