### PR TITLE
feat: implement sliding-window rate limiter for anonymous transactions

### DIFF
--- a/app/api/transaction/submit-anonymous/route.ts
+++ b/app/api/transaction/submit-anonymous/route.ts
@@ -6,11 +6,20 @@
  */
 
 import { NextResponse } from 'next/server';
+import { checkSubmitAnonRateLimit } from '@/lib/rateLimit';
 import { submitTransaction } from '@/lib/stellar/transaction';
 import { verifyAnonymousDonationProof } from '@/lib/zk/prover';
 import { isNullifierUsed } from '@/lib/stellar/anonymous-donation';
 import type { AnonymousDonationProof } from '@/lib/zk/types';
 import type { NetworkType } from '@/lib/types/wallet';
+
+function getClientIp(request: Request): string {
+  return (
+    request.headers.get('x-forwarded-for')?.split(',')[0].trim() ??
+    request.headers.get('x-real-ip') ??
+    '127.0.0.1'
+  );
+}
 
 interface SubmitAnonymousRequest {
   transactionXdr: string;
@@ -21,6 +30,25 @@ interface SubmitAnonymousRequest {
 
 export async function POST(request: Request) {
   try {
+    const ip = getClientIp(request);
+    const rateLimit = checkSubmitAnonRateLimit(ip);
+
+    if (!rateLimit.allowed) {
+      return NextResponse.json(
+        { error: 'Too many anonymous submissions. Please try again later.' },
+        {
+          status: 429,
+          headers: {
+            'Content-Type': 'application/json',
+            'Retry-After': String(rateLimit.retryAfter ?? 3600),
+            'X-RateLimit-Limit': '5',
+            'X-RateLimit-Remaining': '0',
+            'X-RateLimit-Reset': String(Math.ceil(rateLimit.reset / 1000)),
+          },
+        }
+      );
+    }
+
     const body = (await request.json()) as SubmitAnonymousRequest;
     const { transactionXdr, network, proof, nullifier } = body;
 

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -56,3 +56,62 @@ export function checkRateLimit(ip: string, limit = DEFAULT_LIMIT): RateLimitResu
 export function blockIp(ip: string): void {
   BLOCKLIST.add(ip);
 }
+
+// ── Sliding-window rate limiter for anonymous transaction submission ────────
+// Each IP may submit at most 5 anonymous transactions per rolling 1-hour window.
+
+const SUBMIT_ANON_WINDOW_MS = 3_600_000; // 1 hour
+const SUBMIT_ANON_LIMIT = 5;
+
+interface SlidingEntry {
+  timestamps: number[];
+}
+
+const submitAnonWindows = new Map<string, SlidingEntry>();
+
+export type SlidingRateLimitResult =
+  | { allowed: true; remaining: number; reset: number }
+  | {
+      allowed: false;
+      reason: 'blocklist' | 'rate_limit';
+      retryAfter?: number;
+      remaining: number;
+      reset: number;
+    };
+
+export function checkSubmitAnonRateLimit(ip: string): SlidingRateLimitResult {
+  if (BLOCKLIST.has(ip)) {
+    return { allowed: false, reason: 'blocklist', remaining: 0, reset: 0 };
+  }
+
+  const now = Date.now();
+  const cutoff = now - SUBMIT_ANON_WINDOW_MS;
+  const entry = submitAnonWindows.get(ip);
+
+  if (!entry) {
+    submitAnonWindows.set(ip, { timestamps: [now] });
+    return { allowed: true, remaining: SUBMIT_ANON_LIMIT - 1, reset: now + SUBMIT_ANON_WINDOW_MS };
+  }
+
+  // Prune timestamps that have fallen outside the sliding window.
+  entry.timestamps = entry.timestamps.filter((ts) => ts > cutoff);
+
+  if (entry.timestamps.length >= SUBMIT_ANON_LIMIT) {
+    const oldest = entry.timestamps[0];
+    const retryAfter = Math.ceil((oldest + SUBMIT_ANON_WINDOW_MS - now) / 1000);
+    return {
+      allowed: false,
+      reason: 'rate_limit',
+      retryAfter,
+      remaining: 0,
+      reset: oldest + SUBMIT_ANON_WINDOW_MS,
+    };
+  }
+
+  entry.timestamps.push(now);
+  return {
+    allowed: true,
+    remaining: SUBMIT_ANON_LIMIT - entry.timestamps.length,
+    reset: now + SUBMIT_ANON_WINDOW_MS,
+  };
+}


### PR DESCRIPTION
…w balances

Integrate sliding-window rate limiting on the /api/transaction/submit-anonymous endpoint to prevent spam and DDoS attempts on the relayer.

- Limit requests to a maximum of 5 submissions per IP/hour.
- Return HTTP 429 Too Many Requests with correct headers.

closes #673 