### PR TITLE
feat(dashboard): add animated carbon footprint dashboard

### DIFF
--- a/app/dashboard/carbon/page.tsx
+++ b/app/dashboard/carbon/page.tsx
@@ -1,0 +1,17 @@
+import { type Metadata } from 'next';
+import { CarbonDashboard } from '@/components/organisms/CarbonDashboard';
+
+export const metadata: Metadata = {
+  title: 'Carbon Footprint | Stellar App OS',
+  description: 'Track your personal tree contributions, carbon offset projections, and badge accomplishments.',
+};
+
+export default function CarbonDashboardPage() {
+  return (
+    <main className="min-h-screen bg-background pt-24 pb-16 px-4 md:px-8 lg:px-12">
+      <div className="max-w-7xl mx-auto">
+        <CarbonDashboard />
+      </div>
+    </main>
+  );
+}

--- a/components/organisms/CarbonDashboard/BadgesList.tsx
+++ b/components/organisms/CarbonDashboard/BadgesList.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Sprout, TreePine, Leaf, Trophy } from 'lucide-react';
+
+export interface BadgeItem {
+  id: string;
+  name: string;
+  description: string;
+  iconType: 'seed' | 'tree' | 'forest' | 'champion';
+  achieved: boolean;
+  dateAchieved?: string;
+}
+
+interface BadgesListProps {
+  badges: BadgeItem[];
+}
+
+const iconMap = {
+  seed: <Sprout className="w-8 h-8" />,
+  tree: <TreePine className="w-8 h-8" />,
+  forest: <Leaf className="w-8 h-8" />,
+  champion: <Trophy className="w-8 h-8" />,
+};
+
+export function BadgesList({ badges }: BadgesListProps) {
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <CardTitle>Accomplishments</CardTitle>
+        <CardDescription>Badges earned for your environmental impact.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {badges.map((badge) => (
+            <div 
+              key={badge.id}
+              className={`flex flex-col items-center p-4 rounded-lg border transition-colors ${
+                badge.achieved 
+                  ? 'bg-emerald-50 border-emerald-200 dark:bg-emerald-950/20 dark:border-emerald-800' 
+                  : 'bg-slate-50 border-slate-200 opacity-60 dark:bg-slate-900 dark:border-slate-800'
+              }`}
+            >
+              <div className={`mb-3 p-3 rounded-full ${
+                badge.achieved 
+                  ? 'bg-emerald-100 text-emerald-600 dark:bg-emerald-900 dark:text-emerald-400' 
+                  : 'bg-slate-200 text-slate-400 dark:bg-slate-800 dark:text-slate-500'
+              }`}>
+                {iconMap[badge.iconType] || <Trophy className="w-8 h-8" />}
+              </div>
+              <h4 className="font-semibold text-center text-sm mb-1">{badge.name}</h4>
+              <p className="text-xs text-center text-slate-500 dark:text-slate-400 mb-2">
+                {badge.description}
+              </p>
+              {badge.achieved ? (
+                <Badge variant="default" className="bg-emerald-500 hover:bg-emerald-600">Earned</Badge>
+              ) : (
+                <Badge variant="outline">Locked</Badge>
+              )}
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/organisms/CarbonDashboard/CarbonChart.tsx
+++ b/components/organisms/CarbonDashboard/CarbonChart.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface CarbonDataPoint {
+  date: string;
+  offset_kg: number;
+}
+
+interface CarbonChartProps {
+  data: CarbonDataPoint[];
+}
+
+export function CarbonChart({ data }: CarbonChartProps) {
+  // O(N) Time / O(N) Space complexity optimization via useMemo
+  // Prevents re-calculation/re-allocation on re-renders when data hasn't changed.
+  const chartData = useMemo(() => {
+    let cumulative = 0;
+    return data.map((point) => {
+      cumulative += point.offset_kg;
+      return {
+        date: new Date(point.date).toLocaleDateString(undefined, { month: 'short', year: 'numeric' }),
+        rawDate: point.date, // Keep for sorting if needed, though assumed sorted
+        daily_offset: point.offset_kg,
+        cumulative_offset: cumulative,
+      };
+    });
+  }, [data]);
+
+  return (
+    <Card className="w-full h-full">
+      <CardHeader>
+        <CardTitle>Carbon Offset Projection</CardTitle>
+        <CardDescription>Your cumulative carbon footprint reduction over time.</CardDescription>
+      </CardHeader>
+      <CardContent className="h-[300px]">
+        {chartData.length === 0 ? (
+          <div className="flex items-center justify-center h-full text-slate-500">
+            No data available.
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart
+              data={chartData}
+              margin={{ top: 10, right: 10, left: 0, bottom: 0 }}
+            >
+              <defs>
+                <linearGradient id="colorOffset" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#10b981" stopOpacity={0.8} />
+                  <stop offset="95%" stopColor="#10b981" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#e2e8f0" />
+              <XAxis 
+                dataKey="date" 
+                stroke="#64748b" 
+                fontSize={12} 
+                tickLine={false}
+                axisLine={false}
+                minTickGap={30}
+              />
+              <YAxis 
+                stroke="#64748b" 
+                fontSize={12} 
+                tickLine={false}
+                axisLine={false}
+                tickFormatter={(val) => `${val}kg`}
+              />
+              <Tooltip 
+                contentStyle={{ borderRadius: '8px', border: 'none', boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)' }}
+                formatter={(value: number) => [`${value} kg`, 'Total Offset']}
+              />
+              <Area
+                type="monotone"
+                dataKey="cumulative_offset"
+                stroke="#10b981"
+                strokeWidth={3}
+                fillOpacity={1}
+                fill="url(#colorOffset)"
+                isAnimationActive={true}
+                animationDuration={1500}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/organisms/CarbonDashboard/CarbonDashboard.tsx
+++ b/components/organisms/CarbonDashboard/CarbonDashboard.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { CarbonChart } from './CarbonChart';
+import { BadgesList, type BadgeItem } from './BadgesList';
+import { SocialShareCard } from './SocialShareCard';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { TreePine, Wind } from 'lucide-react';
+
+// Static/Dummy Data
+const mockCarbonData = [
+  { date: '2023-01-01', offset_kg: 50 },
+  { date: '2023-02-01', offset_kg: 55 },
+  { date: '2023-03-01', offset_kg: 60 },
+  { date: '2023-04-01', offset_kg: 80 },
+  { date: '2023-05-01', offset_kg: 90 },
+  { date: '2023-06-01', offset_kg: 105 },
+  { date: '2023-07-01', offset_kg: 120 },
+  { date: '2023-08-01', offset_kg: 150 },
+];
+
+const mockBadges: BadgeItem[] = [
+  {
+    id: 'b1',
+    name: 'First Seed',
+    description: 'Sponsored your very first tree on the platform.',
+    iconType: 'seed',
+    achieved: true,
+  },
+  {
+    id: 'b2',
+    name: 'Green Thumb',
+    description: 'Sponsored 10 trees in a single month.',
+    iconType: 'tree',
+    achieved: true,
+  },
+  {
+    id: 'b3',
+    name: 'Forest Guardian',
+    description: 'Reach a total of 100 trees sponsored.',
+    iconType: 'forest',
+    achieved: false,
+  },
+  {
+    id: 'b4',
+    name: 'Carbon Champion',
+    description: 'Offset 1,000kg of CO2 across all your trees.',
+    iconType: 'champion',
+    achieved: false,
+  },
+];
+
+export function CarbonDashboard() {
+  // Aggregate stats from the dummy data
+  const totalTrees = 28; // Hardcoded summary stat for demo
+  const totalOffsetKg = mockCarbonData.reduce((acc, point) => acc + point.offset_kg, 0);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col md:flex-row gap-4 items-start md:items-end justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Carbon Footprint</h1>
+          <p className="text-slate-500 dark:text-slate-400 mt-1">
+            Track your personal environmental impact and achievements.
+          </p>
+        </div>
+      </div>
+
+      {/* High Level Stats Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Total Trees Sponsored</CardTitle>
+            <TreePine className="h-4 w-4 text-emerald-500" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{totalTrees}</div>
+            <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+              +3 this month
+            </p>
+          </CardContent>
+        </Card>
+        
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Total CO2 Offset</CardTitle>
+            <Wind className="h-4 w-4 text-teal-500" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{totalOffsetKg.toLocaleString()} kg</div>
+            <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+              Based on species maturity estimates
+            </p>
+          </CardContent>
+        </Card>
+
+        {/* Social Share Card explicitly placed in the top grid for high visibility */}
+        <div className="md:col-span-1">
+          <SocialShareCard totalTrees={totalTrees} totalOffsetKg={totalOffsetKg} />
+        </div>
+      </div>
+
+      {/* Main Chart Area */}
+      <div className="grid grid-cols-1 gap-6">
+        <CarbonChart data={mockCarbonData} />
+      </div>
+
+      {/* Badges Area */}
+      <div className="grid grid-cols-1 gap-6">
+        <BadgesList badges={mockBadges} />
+      </div>
+    </div>
+  );
+}

--- a/components/organisms/CarbonDashboard/SocialShareCard.tsx
+++ b/components/organisms/CarbonDashboard/SocialShareCard.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Share2, Check, Globe } from 'lucide-react';
+
+interface SocialShareCardProps {
+  totalTrees: number;
+  totalOffsetKg: number;
+}
+
+export function SocialShareCard({ totalTrees, totalOffsetKg }: SocialShareCardProps) {
+  const [copied, setCopied] = useState(false);
+
+  const shareText = `I just planted my ${totalTrees}th tree and offset ${totalOffsetKg.toLocaleString()}kg of CO2 with Harvesta! 🌍🌲 Join me in making a real environmental impact on Stellar.`;
+
+  const handleShare = async () => {
+    // Attempt to use native Web Share API on supported devices
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: 'My Harvesta Impact',
+          text: shareText,
+          url: window.location.origin, // point to home page
+        });
+        return;
+      } catch (err) {
+        console.warn('Share rejected or failed', err);
+      }
+    }
+    
+    // Fallback to Clipboard
+    try {
+      await navigator.clipboard.writeText(shareText);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2500);
+    } catch (err) {
+      console.error('Failed to copy to clipboard', err);
+    }
+  };
+
+  return (
+    <Card className="bg-gradient-to-br from-emerald-500 to-teal-600 text-white overflow-hidden relative border-none shadow-md">
+      <div className="absolute top-0 right-0 p-8 opacity-10 pointer-events-none">
+        <Globe className="w-32 h-32" />
+      </div>
+      <CardHeader>
+        <CardTitle className="text-white text-2xl font-bold">Share Your Impact</CardTitle>
+        <CardDescription className="text-emerald-100">
+          Inspire others to join the movement by sharing your environmental footprint.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="relative z-10">
+        <div className="bg-white/20 p-4 rounded-lg backdrop-blur-sm border border-white/30 text-sm md:text-base leading-relaxed">
+          &quot;{shareText}&quot;
+        </div>
+      </CardContent>
+      <CardFooter>
+        <Button 
+          onClick={handleShare}
+          variant="secondary"
+          className="w-full bg-white text-emerald-700 hover:bg-slate-50 transition-all font-semibold"
+        >
+          {copied ? (
+            <>
+              <Check className="w-4 h-4 mr-2" />
+              Copied to Clipboard!
+            </>
+          ) : (
+            <>
+              <Share2 className="w-4 h-4 mr-2" />
+              Share on Social Media
+            </>
+          )}
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/components/organisms/CarbonDashboard/index.ts
+++ b/components/organisms/CarbonDashboard/index.ts
@@ -1,0 +1,4 @@
+export * from './CarbonDashboard';
+export * from './CarbonChart';
+export * from './SocialShareCard';
+export * from './BadgesList';


### PR DESCRIPTION
closes #660 

# Summary
Added the new carbon dashboard route at /dashboard/carbon.
Implemented an animated Recharts progress graph for carbon offset projection.
Added a shareable social summary card with Web Share API and clipboard fallback.
Added accomplishments/badges and summary stats for trees and offset progress.

# Reason
This delivers the requested frontend feature for issue #660.
It covers the acceptance criteria for animated graphs and shareable summary cards.


