### PR TITLE
Add EXIF metadata preview modal for tree photo uploads Closes #843

### DIFF
--- a/components/molecules/ThumbnailErrorBoundary.tsx
+++ b/components/molecules/ThumbnailErrorBoundary.tsx
@@ -1,0 +1,31 @@
+import { Component, type ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  fallback: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+/**
+ * Isolates the thumbnail preview so a corrupt image or an object-URL
+ * revoked mid-render can't take the whole verification ticket down with it.
+ */
+export class ThumbnailErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown) {
+    // eslint-disable-next-line no-console
+    console.error("Photo thumbnail failed to render:", error);
+  }
+
+  render() {
+    return this.state.hasError ? this.props.fallback : this.props.children;
+  }
+}

--- a/components/organisms/PhotoMetadataModal.test.tsx
+++ b/components/organisms/PhotoMetadataModal.test.tsx
@@ -1,0 +1,204 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { PhotoMetadataModal } from "./PhotoMetadataModal";
+import type { ExifParser, PhotoMetadata } from "./types";
+
+function makeFile(name = "tree.jpg") {
+  return new File(["fake-jpeg-bytes"], name, { type: "image/jpeg" });
+}
+
+function deferredParser() {
+  let resolve!: (value: PhotoMetadata) => void;
+  let reject!: (err: Error) => void;
+  const promise = new Promise<PhotoMetadata>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  const parser: ExifParser = () => promise;
+  return { parser, resolve, reject };
+}
+
+const WITH_GPS: PhotoMetadata = {
+  gps: { latitude: 6.5244, longitude: 3.3792, altitude: 41 },
+  capturedAt: new Date(2026, 6, 24, 9, 15, 32),
+  deviceMake: "Google",
+  deviceModel: "Pixel 8",
+};
+
+const NO_METADATA: PhotoMetadata = {
+  gps: null,
+  capturedAt: null,
+  deviceMake: null,
+  deviceModel: null,
+};
+
+describe("PhotoMetadataModal", () => {
+  it("renders nothing when closed", () => {
+    const parser: ExifParser = () => new Promise(() => {}); // never resolves - irrelevant while closed
+    const { container } = render(
+      <PhotoMetadataModal file={makeFile()} isOpen={false} onClose={vi.fn()} onConfirm={vi.fn()} parser={parser} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows a loading state, then the extracted GPS, timestamp, and device once resolved", async () => {
+    const { parser, resolve } = deferredParser();
+    render(
+      <PhotoMetadataModal file={makeFile()} isOpen onClose={vi.fn()} onConfirm={vi.fn()} parser={parser} />
+    );
+
+    expect(screen.getByTestId("status-stamp")).toHaveTextContent(/reading/i);
+    expect(screen.getByRole("button", { name: /confirm & submit/i })).toBeDisabled();
+
+    resolve(WITH_GPS);
+
+    await waitFor(() => expect(screen.getByTestId("status-stamp")).toHaveTextContent(/gps locked/i));
+    expect(screen.getByText(/6\.52440.*3\.37920/)).toBeInTheDocument();
+    expect(screen.getByText("Google Pixel 8")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /confirm & submit/i })).toBeEnabled();
+  });
+
+  it("flags photos with no usable metadata instead of failing", async () => {
+    const parser: ExifParser = async () => NO_METADATA;
+    render(
+      <PhotoMetadataModal file={makeFile()} isOpen onClose={vi.fn()} onConfirm={vi.fn()} parser={parser} />
+    );
+
+    await waitFor(() => expect(screen.getByTestId("status-stamp")).toHaveTextContent(/no gps data/i));
+    expect(screen.getByText("No GPS data found")).toBeInTheDocument();
+    expect(screen.getByText(/missing location data/i)).toBeInTheDocument();
+    // Missing data is a warning, not a hard stop - submission stays available.
+    expect(screen.getByRole("button", { name: /confirm & submit/i })).toBeEnabled();
+  });
+
+  it("shows a retry affordance when extraction fails, and recovers on retry", async () => {
+    let callCount = 0;
+    const parser: ExifParser = async () => {
+      callCount += 1;
+      if (callCount === 1) throw new Error("Unsupported file format");
+      return WITH_GPS;
+    };
+    const user = userEvent.setup();
+    render(
+      <PhotoMetadataModal file={makeFile()} isOpen onClose={vi.fn()} onConfirm={vi.fn()} parser={parser} />
+    );
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    expect(screen.getByText(/unsupported file format/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /confirm & submit/i })).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: /try again/i }));
+
+    await waitFor(() => expect(screen.getByTestId("status-stamp")).toHaveTextContent(/gps locked/i));
+  });
+
+  it("calls onConfirm with the extracted metadata", async () => {
+    const parser: ExifParser = async () => WITH_GPS;
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <PhotoMetadataModal file={makeFile()} isOpen onClose={vi.fn()} onConfirm={onConfirm} parser={parser} />
+    );
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /confirm & submit/i })).toBeEnabled());
+    await user.click(screen.getByRole("button", { name: /confirm & submit/i }));
+
+    expect(onConfirm).toHaveBeenCalledWith(WITH_GPS);
+  });
+
+  it("closes on Escape and on backdrop click, but not on panel click", async () => {
+    const parser: ExifParser = async () => WITH_GPS;
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <PhotoMetadataModal file={makeFile()} isOpen onClose={onClose} onConfirm={vi.fn()} parser={parser} />
+    );
+
+    await user.click(screen.getByRole("dialog"));
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("locks body scroll while open and restores it on close", async () => {
+    const parser: ExifParser = async () => WITH_GPS;
+    const file = makeFile();
+    const { rerender } = render(
+      <PhotoMetadataModal file={file} isOpen onClose={vi.fn()} onConfirm={vi.fn()} parser={parser} />
+    );
+    await waitFor(() => expect(screen.getByTestId("status-stamp")).toHaveTextContent(/gps locked/i));
+    expect(document.body.style.overflow).toBe("hidden");
+
+    rerender(
+      <PhotoMetadataModal file={file} isOpen={false} onClose={vi.fn()} onConfirm={vi.fn()} parser={parser} />
+    );
+    expect(document.body.style.overflow).not.toBe("hidden");
+  });
+
+  it("renders nothing when open but no file is provided", () => {
+    const { container } = render(
+      <PhotoMetadataModal file={null} isOpen onClose={vi.fn()} onConfirm={vi.fn()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("traps Tab focus inside the dialog", async () => {
+    const parser: ExifParser = async () => WITH_GPS;
+    const user = userEvent.setup();
+    render(
+      <PhotoMetadataModal file={makeFile()} isOpen onClose={vi.fn()} onConfirm={vi.fn()} parser={parser} />
+    );
+    await waitFor(() => expect(screen.getByRole("button", { name: /confirm & submit/i })).toBeEnabled());
+
+    const closeButton = screen.getByRole("button", { name: /close/i });
+    const confirmButton = screen.getByRole("button", { name: /confirm & submit/i });
+
+    confirmButton.focus();
+    await user.tab();
+    expect(document.activeElement).toBe(closeButton); // wraps from last back to first
+
+    closeButton.focus();
+    await user.tab({ shift: true });
+    expect(document.activeElement).toBe(confirmButton); // wraps from first back to last
+  });
+
+  it("does not restart extraction when the caller passes a new, non-memoized parser on every render", async () => {
+    let callCount = 0;
+    const makeParser = (): ExifParser => async () => {
+      callCount += 1;
+      return WITH_GPS;
+    };
+    const file = makeFile();
+
+    const { rerender } = render(
+      <PhotoMetadataModal file={file} isOpen onClose={vi.fn()} onConfirm={vi.fn()} parser={makeParser()} />
+    );
+    await waitFor(() => expect(callCount).toBe(1));
+
+    // Simulate a parent re-render that recreates the parser inline each time.
+    rerender(
+      <PhotoMetadataModal file={file} isOpen onClose={vi.fn()} onConfirm={vi.fn()} parser={makeParser()} />
+    );
+    rerender(
+      <PhotoMetadataModal file={file} isOpen onClose={vi.fn()} onConfirm={vi.fn()} parser={makeParser()} />
+    );
+
+    expect(callCount).toBe(1); // same File instance -> extraction should not re-run
+  });
+
+  it("is an accessible dialog labelled by its heading, with focus on the close button", async () => {
+    const parser: ExifParser = async () => WITH_GPS;
+    render(
+      <PhotoMetadataModal file={makeFile()} isOpen onClose={vi.fn()} onConfirm={vi.fn()} parser={parser} />
+    );
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    const labelId = dialog.getAttribute("aria-labelledby");
+    expect(document.getElementById(labelId!)).toHaveTextContent(/verify photo details/i);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /close/i })).toHaveFocus());
+  });
+});

--- a/components/organisms/PhotoMetadataModal.tsx
+++ b/components/organisms/PhotoMetadataModal.tsx
@@ -1,0 +1,289 @@
+import { useEffect, useId, useRef, useState } from "react";
+import { useExifData } from "./useExifData";
+import { ThumbnailErrorBoundary } from "./ThumbnailErrorBoundary";
+import { formatAltitude, formatCapturedAt, formatCoordinates } from "./format";
+import type { ExifParser, PhotoMetadata } from "./types";
+
+export interface PhotoMetadataModalProps {
+  /** The photo the person just picked. Pass null to keep the modal closed. */
+  file: File | null;
+  isOpen: boolean;
+  onClose: () => void;
+  /** Called when the person accepts the extracted details and wants to submit the photo. */
+  onConfirm: (metadata: PhotoMetadata | null) => void;
+  /**
+   * Override for tests, or to swap in a richer parser later.
+   * Note: the default parser only reads JPEG's APP1/EXIF segment. HEIC
+   * (the default capture format on iPhone unless "Most Compatible" is on)
+   * isn't parsed yet - it falls through to the "no GPS data" warning state
+   * rather than erroring, but a HEIC-aware parser is a known follow-up.
+   */
+  parser?: ExifParser;
+}
+
+function StatusStamp({ state }: { state: "locked" | "missing" | "reading" }) {
+  const copy = {
+    locked: "GPS LOCKED",
+    missing: "NO GPS DATA",
+    reading: "READING\u2026",
+  }[state];
+
+  // stellar-navy/stellar-green/stellar-blue are flat single-value brand
+  // colors (no 50-900 scale) - opacity modifiers stand in for tints/shades
+  // instead of assuming shade steps that don't exist in the design system.
+  const tone = {
+    locked: "border-stellar-green text-stellar-green bg-stellar-green/10",
+    missing: "border-red-600 text-red-700 bg-red-50",
+    reading: "border-stellar-navy/30 text-stellar-navy/60 bg-stellar-navy/5",
+  }[state];
+
+  return (
+    <span
+      className={`pointer-events-none absolute -right-3 -top-3 rotate-6 select-none rounded-sm border-2 px-2 py-1 font-mono text-[10px] font-bold tracking-widest shadow-sm ${tone}`}
+      data-testid="status-stamp"
+    >
+      {copy}
+    </span>
+  );
+}
+
+function DataRow({
+  label,
+  value,
+  status,
+}: {
+  label: string;
+  value: string;
+  status: "ok" | "missing";
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-dashed border-stellar-navy/15 py-2.5 last:border-b-0">
+      <span className="font-serif text-sm text-stellar-navy/60">{label}</span>
+      <span
+        className={`font-mono text-sm ${
+          status === "ok" ? "text-stellar-navy" : "italic text-stellar-navy/40"
+        }`}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function RowSkeleton() {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-dashed border-stellar-navy/15 py-2.5 last:border-b-0">
+      <div className="h-3 w-20 animate-pulse rounded bg-stellar-navy/10" />
+      <div className="h-3 w-32 animate-pulse rounded bg-stellar-navy/10" />
+    </div>
+  );
+}
+
+export function PhotoMetadataModal({
+  file,
+  isOpen,
+  onClose,
+  onConfirm,
+  parser,
+}: PhotoMetadataModalProps) {
+  const { status, metadata, error, retry } = useExifData(file, parser);
+  const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+
+  useEffect(() => {
+    if (!file) {
+      setThumbnailUrl(null);
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    setThumbnailUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
+
+  useEffect(() => {
+    if (isOpen) closeButtonRef.current?.focus();
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab" || !panelRef.current) return;
+
+      const focusable = panelRef.current.querySelectorAll<HTMLElement>(
+        'button:not(:disabled), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen || !file) return null;
+
+  const isLoading = status === "reading";
+  const hasGps = status === "success" && Boolean(metadata?.gps);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-stellar-navy/50 p-0 backdrop-blur-[1px] sm:items-center sm:p-4"
+      onClick={onClose}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        onClick={(event) => event.stopPropagation()}
+        className="relative w-full max-w-md rounded-t-2xl border-t-4 border-dashed border-stellar-blue bg-stellar-navy/5 p-5 shadow-xl sm:rounded-2xl sm:border-t-4"
+      >
+        {status !== "error" && (
+          <StatusStamp state={isLoading ? "reading" : hasGps ? "locked" : "missing"} />
+        )}
+
+        <div className="mb-4 flex items-start justify-between gap-4">
+          <div>
+            <p className="font-mono text-[11px] uppercase tracking-widest text-stellar-blue">
+              Field verification ticket
+            </p>
+            <h2 id={titleId} className="font-serif text-lg font-semibold text-stellar-navy">
+              Verify photo details
+            </h2>
+          </div>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-full p-1.5 text-stellar-navy/40 transition hover:bg-stellar-navy/5 hover:text-stellar-navy focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-stellar-green"
+          >
+            <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true" fill="none">
+              <path d="M2 2L16 16M16 2L2 16" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+
+        <ThumbnailErrorBoundary
+          fallback={
+            <div className="mb-4 flex h-40 items-center justify-center rounded-lg border border-stellar-navy/15 bg-stellar-navy/5 text-sm text-stellar-navy/40">
+              Preview unavailable
+            </div>
+          }
+        >
+          {thumbnailUrl ? (
+            <img
+              src={thumbnailUrl}
+              alt="Tree photo pending submission"
+              className="mb-4 h-40 w-full rounded-lg border border-stellar-navy/15 object-cover"
+            />
+          ) : (
+            <div className="mb-4 h-40 w-full animate-pulse rounded-lg bg-stellar-navy/10" />
+          )}
+        </ThumbnailErrorBoundary>
+
+        {status === "error" ? (
+          <div
+            role="alert"
+            className="mb-4 rounded-lg border border-red-300 bg-red-50 p-3 text-sm text-red-700"
+          >
+            <p className="font-medium">Couldn&apos;t read this photo&apos;s details.</p>
+            <p className="mt-0.5 text-red-600">{error}</p>
+            <button
+              type="button"
+              onClick={retry}
+              className="mt-2 rounded-md border border-red-400 px-3 py-1 text-xs font-semibold text-red-700 transition hover:bg-red-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600"
+            >
+              Try again
+            </button>
+          </div>
+        ) : (
+          <div className="mb-5 rounded-lg bg-stellar-navy/5 px-3">
+            {isLoading ? (
+              <>
+                <RowSkeleton />
+                <RowSkeleton />
+                <RowSkeleton />
+              </>
+            ) : (
+              <>
+                <DataRow
+                  label="Location"
+                  value={
+                    metadata?.gps
+                      ? formatCoordinates(metadata.gps) +
+                        (metadata.gps.altitude ? ` \u00b7 ${formatAltitude(metadata.gps.altitude)}` : "")
+                      : "No GPS data found"
+                  }
+                  status={metadata?.gps ? "ok" : "missing"}
+                />
+                <DataRow
+                  label="Captured"
+                  value={metadata?.capturedAt ? formatCapturedAt(metadata.capturedAt) : "Not available"}
+                  status={metadata?.capturedAt ? "ok" : "missing"}
+                />
+                <DataRow
+                  label="Device"
+                  value={
+                    metadata?.deviceMake || metadata?.deviceModel
+                      ? [metadata.deviceMake, metadata.deviceModel].filter(Boolean).join(" ")
+                      : "Unknown device"
+                  }
+                  status={metadata?.deviceMake || metadata?.deviceModel ? "ok" : "missing"}
+                />
+              </>
+            )}
+          </div>
+        )}
+
+        {!isLoading && status !== "error" && !hasGps && (
+          <p className="mb-4 text-xs leading-relaxed text-stellar-navy/60">
+            This photo is missing location data, so it may need manual review before it counts
+            toward your credit. You can still submit it.
+          </p>
+        )}
+
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 rounded-lg border border-stellar-navy/30 py-2.5 text-sm font-semibold text-stellar-navy transition hover:bg-stellar-navy/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-stellar-green"
+          >
+            Retake photo
+          </button>
+          <button
+            type="button"
+            disabled={isLoading || status === "error"}
+            onClick={() => onConfirm(metadata)}
+            className="flex-1 rounded-lg bg-stellar-green py-2.5 text-sm font-semibold text-white transition hover:bg-stellar-green/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-stellar-green disabled:cursor-not-allowed disabled:bg-stellar-navy/10 disabled:text-stellar-navy/30"
+          >
+            Confirm &amp; submit
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/tailwind.tokens.md
+++ b/docs/tailwind.tokens.md
@@ -1,0 +1,57 @@
+# Design tokens used by PhotoMetadataModal
+
+This component keeps a "field verification ticket" concept - tree photo
+submissions are proof-of-work for an agricultural credit, so the modal reads
+like a field surveyor's log rather than a generic photo dialog: a dashed
+perforated edge, monospace data rows, and a rotated ink-stamp badge that
+reports GPS LOCKED / NO GPS DATA the moment extraction resolves.
+
+## Colors: flat brand tokens + opacity modifiers, not a shade scale
+
+Per the repo README, `stellar-blue` (`#14B6E7`), `stellar-navy` (`#0D0B21`),
+and `stellar-green` (`#00B36B`) are flat single-value colors - there's no
+`50`-`900` scale. So instead of guessing at shade numbers that may not exist
+in `tailwind.config.js`, every tint/shade in this component is done with
+Tailwind's opacity modifier syntax on the flat token, which works regardless
+of what scale (if any) is configured:
+
+| Role                                              | Class pattern used              |
+|----------------------------------------------------|----------------------------------|
+| Ink / text / neutral structure ("bark")             | `text-stellar-navy` (full), `text-stellar-navy/60` (secondary), `text-stellar-navy/40` (muted) |
+| Ticket surface / subtle backgrounds ("paper")       | `bg-stellar-navy/5`             |
+| Borders / dividers                                  | `border-stellar-navy/15` (hairline), `border-stellar-navy/30` (visible) |
+| Confirmed / positive state, submit action ("canopy")| `bg-stellar-green`, `text-stellar-green`, `border-stellar-green` (full - no opacity needed, this is the one place full saturation reads as intentional rather than loud) |
+| Structural accent - perforation edge, eyebrow label ("soil") | `border-stellar-blue`, `text-stellar-blue` (full) |
+| Text on a solid `stellar-green` button              | `text-white` - a functional contrast color, not a brand token; opacity-modified navy can't produce "light text," only translucency |
+| Error state only ("flag")                           | Tailwind's default `red-*` scale (50/300/400/600/700) - `red` **does** ship with a full shade scale out of the box, so no assumption is being made there; used only for hard failures (extraction error), never for the "missing GPS" warning, which stays on `stellar-navy` |
+
+No `theme.extend` changes are required at all - every class above works
+against the three flat colors as documented, with zero assumptions about
+scale.
+
+## Optional: typography
+
+`font-serif` (ticket heading) and `font-mono` (data rows, stamp, eyebrow
+label) currently resolve to Tailwind's default serif/mono stacks, which is a
+quieter, less distinctive version of the intended look. If you want the full
+"field ticket" typographic identity, add this to `theme.extend.fontFamily`
+in `tailwind.config.js`:
+
+```js
+fontFamily: {
+  serif: ["Roboto Slab", "ui-serif", "Georgia", "serif"],
+  mono: ["ui-monospace", "SFMono-Regular", "Menlo", "monospace"],
+},
+```
+
+This is a deliberate, separate call from the color mapping above - the
+component works and looks reasonable without it, so treat this as a
+"nice to have" a reviewer can accept or skip rather than something bundled
+in silently.
+
+## Known limitation: JPEG only
+
+`parseJpegExif` walks JPEG's APP1/EXIF segment only. HEIC (the default
+capture format on iPhone unless "Most Compatible" is enabled) isn't parsed
+and falls through to the "no GPS data" warning state rather than erroring.
+Flagged in the PR description as a follow-up, not an oversight.

--- a/hooks/useExifData.ts
+++ b/hooks/useExifData.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef, useState } from "react";
+import { parseJpegExif } from "./exifParser";
+import type { ExifParser, ExtractionResult, PhotoMetadata } from "./types";
+
+function hasUsableMetadata(metadata: PhotoMetadata): boolean {
+  return Boolean(metadata.gps || metadata.capturedAt || metadata.deviceMake || metadata.deviceModel);
+}
+
+/**
+ * Extracts EXIF metadata from a file entirely in the browser - the file
+ * never leaves the device for this preview step. Exposes a `retry` so the
+ * UI can recover from a transient read failure without asking the person
+ * to re-pick the photo.
+ */
+export function useExifData(file: File | null, parser: ExifParser = parseJpegExif): ExtractionResult & { retry: () => void } {
+  const [result, setResult] = useState<ExtractionResult>({
+    status: file ? "reading" : "idle",
+    metadata: null,
+    error: null,
+  });
+  const [retryCount, setRetryCount] = useState(0);
+
+  // Kept out of the effect's dependency array on purpose: a caller that
+  // passes an inline (non-memoized) parser would otherwise re-trigger
+  // extraction on every one of its own re-renders, not just when the file
+  // actually changes. The ref always points at the latest parser without
+  // forcing that.
+  const parserRef = useRef(parser);
+  useEffect(() => {
+    parserRef.current = parser;
+  }, [parser]);
+
+  useEffect(() => {
+    if (!file) {
+      setResult({ status: "idle", metadata: null, error: null });
+      return;
+    }
+
+    let cancelled = false;
+    setResult({ status: "reading", metadata: null, error: null });
+
+    parserRef
+      .current(file)
+      .then((metadata) => {
+        if (cancelled) return;
+        setResult({
+          status: hasUsableMetadata(metadata) ? "success" : "no-metadata",
+          metadata,
+          error: null,
+        });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : "Could not read this photo's details.";
+        setResult({ status: "error", metadata: null, error: message });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // `retryCount` intentionally retriggers this effect on retry().
+  }, [file, retryCount]);
+
+  return {
+    ...result,
+    retry: () => setRetryCount((count) => count + 1),
+  };
+}

--- a/lib/exif/exifParser.test.ts
+++ b/lib/exif/exifParser.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+import { parseJpegExif } from "./exifParser";
+
+type FieldSpec =
+  | { tag: number; type: 2; ascii: string } // ASCII, null-terminated
+  | { tag: number; type: 5; rationals: [number, number][] }; // unsigned rational
+
+interface IfdSpec {
+  fields: FieldSpec[];
+  /** Populated after layout: tiffStart-relative offset of this IFD's directory. */
+  offset?: number;
+}
+
+/**
+ * Lays out a minimal little-endian TIFF/EXIF structure: IFD0 (Make, Model,
+ * pointers to the Exif and GPS sub-IFDs), an Exif IFD (DateTimeOriginal),
+ * and a GPS IFD (lat/lon ref + rationals) - then wraps it in a JPEG APP1
+ * segment. Only exercises the fields PhotoMetadataModal actually reads.
+ */
+function buildFakeJpegWithExif({
+  make,
+  model,
+  dateTimeOriginal,
+  latRef,
+  lat,
+  lonRef,
+  lon,
+}: {
+  make: string;
+  model: string;
+  dateTimeOriginal: string;
+  latRef: "N" | "S";
+  lat: [number, number][];
+  lonRef: "E" | "W";
+  lon: [number, number][];
+}): ArrayBuffer {
+  const ifd0: IfdSpec = {
+    fields: [
+      { tag: 0x010f, type: 2, ascii: make },
+      { tag: 0x0110, type: 2, ascii: model },
+      // Pointers filled in below once sub-IFD offsets are known.
+    ],
+  };
+  const exifIfd: IfdSpec = { fields: [{ tag: 0x9003, type: 2, ascii: dateTimeOriginal }] };
+  const gpsIfd: IfdSpec = {
+    fields: [
+      { tag: 0x0001, type: 2, ascii: latRef },
+      { tag: 0x0002, type: 5, rationals: lat },
+      { tag: 0x0003, type: 2, ascii: lonRef },
+      { tag: 0x0004, type: 5, rationals: lon },
+    ],
+  };
+
+  const dirSize = (ifd: IfdSpec) => 2 + ifd.fields.length * 12 + 4;
+
+  // IFD0 needs two extra pointer fields whose values we know are LONGs.
+  const ifd0FieldCount = ifd0.fields.length + 2;
+  const ifd0Size = 2 + ifd0FieldCount * 12 + 4;
+
+  let cursor = 8 + ifd0Size; // tiffStart-relative: IFD0 directory starts at 8
+
+  // Assign external-data offsets for IFD0's own fields (Make/Model).
+  const ifd0DataOffsets = ifd0.fields.map((field) => {
+    const start = cursor;
+    const ascii = field as Extract<FieldSpec, { type: 2 }>;
+    cursor += ascii.ascii.length + 1;
+    return start;
+  });
+
+  const exifIfdOffset = cursor;
+  cursor += dirSize(exifIfd);
+  const exifDataOffsets = exifIfd.fields.map((field) => {
+    const start = cursor;
+    const ascii = field as Extract<FieldSpec, { type: 2 }>;
+    cursor += ascii.ascii.length + 1;
+    return start;
+  });
+
+  const gpsIfdOffset = cursor;
+  cursor += dirSize(gpsIfd);
+  const gpsDataOffsets = gpsIfd.fields.map((field) => {
+    const start = cursor;
+    if (field.type === 2) {
+      if (field.ascii.length + 1 <= 4) return -1; // inline, no external data
+      cursor += field.ascii.length + 1;
+    } else {
+      cursor += field.rationals.length * 8;
+    }
+    return start;
+  });
+
+  const tiffSize = cursor;
+  const tiffStart = 12; // after SOI(2) + APP1 marker(2) + length(2) + "Exif\0\0"(6)
+  const totalSize = tiffStart + tiffSize;
+  const buffer = new ArrayBuffer(totalSize);
+  const view = new DataView(buffer);
+  const bytes = new Uint8Array(buffer);
+
+  view.setUint16(0, 0xffd8); // SOI
+  view.setUint16(2, 0xffe1); // APP1
+  view.setUint16(4, 2 + 6 + tiffSize); // segment length (big-endian per JPEG spec)
+  "Exif\0\0".split("").forEach((ch, i) => bytes.set([ch.charCodeAt(0)], 6 + i));
+
+  view.setUint16(tiffStart, 0x4949, true); // "II" little-endian
+  view.setUint16(tiffStart + 2, 42, true);
+  view.setUint32(tiffStart + 4, 8, true); // IFD0 offset
+
+  function writeAsciiInline(entryValueOffset: number, text: string) {
+    for (let i = 0; i < 4; i++) bytes[entryValueOffset + i] = i < text.length ? text.charCodeAt(i) : 0;
+  }
+  function writeAsciiExternal(dataOffset: number, text: string) {
+    for (let i = 0; i < text.length; i++) bytes[dataOffset + i] = text.charCodeAt(i);
+    bytes[dataOffset + text.length] = 0;
+  }
+  function writeRationalsExternal(dataOffset: number, rationals: [number, number][]) {
+    rationals.forEach(([n, d], i) => {
+      view.setUint32(dataOffset + i * 8, n, true);
+      view.setUint32(dataOffset + i * 8 + 4, d, true);
+    });
+  }
+
+  function writeIfd(dirOffset: number, ifd: IfdSpec, dataOffsets: number[], extraEntries: { tag: number; type: number; count: number; value: number }[] = []) {
+    const abs = tiffStart + dirOffset;
+    const totalEntries = ifd.fields.length + extraEntries.length;
+    view.setUint16(abs, totalEntries, true);
+
+    ifd.fields.forEach((field, i) => {
+      const entryOffset = abs + 2 + i * 12;
+      const count = field.type === 2 ? field.ascii.length + 1 : field.rationals.length;
+      view.setUint16(entryOffset, field.tag, true);
+      view.setUint16(entryOffset + 2, field.type, true);
+      view.setUint32(entryOffset + 4, count, true);
+      const valueFieldOffset = entryOffset + 8;
+
+      if (field.type === 2 && field.ascii.length + 1 <= 4) {
+        writeAsciiInline(valueFieldOffset, field.ascii);
+      } else {
+        view.setUint32(valueFieldOffset, dataOffsets[i], true);
+        if (field.type === 2) writeAsciiExternal(tiffStart + dataOffsets[i], field.ascii);
+        else writeRationalsExternal(tiffStart + dataOffsets[i], field.rationals);
+      }
+    });
+
+    extraEntries.forEach((entry, i) => {
+      const entryOffset = abs + 2 + (ifd.fields.length + i) * 12;
+      view.setUint16(entryOffset, entry.tag, true);
+      view.setUint16(entryOffset + 2, entry.type, true);
+      view.setUint32(entryOffset + 4, entry.count, true);
+      view.setUint32(entryOffset + 8, entry.value, true);
+    });
+
+    view.setUint32(abs + 2 + totalEntries * 12, 0, true); // next IFD offset (none)
+  }
+
+  writeIfd(8, ifd0, ifd0DataOffsets, [
+    { tag: 0x8769, type: 4, count: 1, value: exifIfdOffset },
+    { tag: 0x8825, type: 4, count: 1, value: gpsIfdOffset },
+  ]);
+  writeIfd(exifIfdOffset, exifIfd, exifDataOffsets);
+  writeIfd(gpsIfdOffset, gpsIfd, gpsDataOffsets);
+
+  return buffer;
+}
+
+function bufferToFile(buffer: ArrayBuffer) {
+  return new File([buffer], "tree.jpg", { type: "image/jpeg" });
+}
+
+describe("parseJpegExif", () => {
+  it("extracts device, timestamp, and GPS position from a JPEG's EXIF segment", async () => {
+    const buffer = buildFakeJpegWithExif({
+      make: "Google",
+      model: "Pixel 8",
+      dateTimeOriginal: "2026:07:24 09:15:32",
+      latRef: "N",
+      lat: [
+        [6, 1],
+        [31, 1],
+        [2784, 100], // 6°31'27.84"N
+      ],
+      lonRef: "E",
+      lon: [
+        [3, 1],
+        [22, 1],
+        [4512, 100],
+      ],
+    });
+
+    const metadata = await parseJpegExif(bufferToFile(buffer));
+
+    expect(metadata.deviceMake).toBe("Google");
+    expect(metadata.deviceModel).toBe("Pixel 8");
+    expect(metadata.capturedAt?.toISOString().slice(0, 10)).toBe("2026-07-24");
+    expect(metadata.gps?.latitude).toBeCloseTo(6.5244, 3);
+    expect(metadata.gps?.longitude).toBeCloseTo(3.3792, 3);
+  });
+
+  it("flips the sign for southern and western hemispheres", async () => {
+    const buffer = buildFakeJpegWithExif({
+      make: "Apple",
+      model: "iPhone 15",
+      dateTimeOriginal: "2026:03:11 14:00:00",
+      latRef: "S",
+      lat: [
+        [23, 1],
+        [33, 1],
+        [0, 1],
+      ],
+      lonRef: "W",
+      lon: [
+        [46, 1],
+        [38, 1],
+        [0, 1],
+      ],
+    });
+
+    const metadata = await parseJpegExif(bufferToFile(buffer));
+
+    expect(metadata.gps?.latitude).toBeLessThan(0);
+    expect(metadata.gps?.longitude).toBeLessThan(0);
+  });
+
+  it("returns empty metadata for a file with no EXIF segment", async () => {
+    const plainJpeg = new File([new Uint8Array([0xff, 0xd8, 0xff, 0xd9])], "plain.jpg", {
+      type: "image/jpeg",
+    });
+
+    const metadata = await parseJpegExif(plainJpeg);
+
+    expect(metadata.gps).toBeNull();
+    expect(metadata.capturedAt).toBeNull();
+    expect(metadata.deviceMake).toBeNull();
+  });
+});

--- a/lib/exif/exifParser.ts
+++ b/lib/exif/exifParser.ts
@@ -1,0 +1,190 @@
+import type { PhotoMetadata } from "./types";
+
+/**
+ * Minimal, dependency-free EXIF reader for JPEG files.
+ *
+ * Walks the JPEG segment markers to find the APP1 (EXIF) segment, then reads
+ * the embedded TIFF structure well enough to pull the three fields this
+ * modal cares about: GPS position, capture timestamp, and device make/model.
+ * It intentionally does not attempt to parse every EXIF tag - only what the
+ * UI displays - to keep the client bundle small.
+ */
+
+const JPEG_SOI = 0xffd8;
+const APP1_MARKER = 0xffe1;
+const EXIF_HEADER = "Exif\0\0";
+
+const TAG_MAKE = 0x010f;
+const TAG_MODEL = 0x0110;
+const TAG_DATETIME_ORIGINAL = 0x9003;
+const TAG_DATETIME = 0x0132;
+const TAG_EXIF_IFD_POINTER = 0x8769;
+const TAG_GPS_IFD_POINTER = 0x8825;
+const TAG_GPS_LAT_REF = 0x0001;
+const TAG_GPS_LAT = 0x0002;
+const TAG_GPS_LON_REF = 0x0003;
+const TAG_GPS_LON = 0x0004;
+const TAG_GPS_ALTITUDE_REF = 0x0005;
+const TAG_GPS_ALTITUDE = 0x0006;
+
+class TiffReader {
+  constructor(
+    private view: DataView,
+    private littleEndian: boolean,
+    /** Offset of the start of the TIFF header within the source buffer. */
+    private tiffStart: number
+  ) {}
+
+  u16(offset: number): number {
+    return this.view.getUint16(offset, this.littleEndian);
+  }
+
+  u32(offset: number): number {
+    return this.view.getUint32(offset, this.littleEndian);
+  }
+
+  /** Reads one IFD (Image File Directory) and returns its tag -> raw entry map. */
+  readIfd(ifdOffset: number): Map<number, { type: number; count: number; valueOffset: number }> {
+    const absolute = this.tiffStart + ifdOffset;
+    const entryCount = this.u16(absolute);
+    const entries = new Map<number, { type: number; count: number; valueOffset: number }>();
+
+    for (let i = 0; i < entryCount; i++) {
+      const entryOffset = absolute + 2 + i * 12;
+      const tag = this.u16(entryOffset);
+      const type = this.u16(entryOffset + 2);
+      const count = this.u32(entryOffset + 4);
+      entries.set(tag, { type, count, valueOffset: entryOffset + 8 });
+    }
+    return entries;
+  }
+
+  readAscii(entry: { count: number; valueOffset: number }): string {
+    const dataOffset =
+      entry.count > 4 ? this.tiffStart + this.u32(entry.valueOffset) : entry.valueOffset;
+    const bytes: number[] = [];
+    for (let i = 0; i < entry.count - 1; i++) {
+      bytes.push(this.view.getUint8(dataOffset + i));
+    }
+    return String.fromCharCode(...bytes).trim();
+  }
+
+  readRational(offset: number): number {
+    const numerator = this.u32(offset);
+    const denominator = this.u32(offset + 4);
+    return denominator === 0 ? 0 : numerator / denominator;
+  }
+
+  /** GPS lat/lon are stored as 3 rationals (degrees, minutes, seconds). */
+  readGpsCoordinate(entry: { count: number; valueOffset: number }): number {
+    const dataOffset = this.tiffStart + this.u32(entry.valueOffset);
+    const degrees = this.readRational(dataOffset);
+    const minutes = this.readRational(dataOffset + 8);
+    const seconds = this.readRational(dataOffset + 16);
+    return degrees + minutes / 60 + seconds / 3600;
+  }
+
+  readByteOrShort(entry: { type: number; valueOffset: number }): number {
+    return entry.type === 1 ? this.view.getUint8(entry.valueOffset) : this.u16(entry.valueOffset);
+  }
+}
+
+function parseExifDate(raw: string): Date | null {
+  // EXIF timestamps look like "2026:07:24 09:15:32".
+  const match = raw.match(/^(\d{4}):(\d{2}):(\d{2}) (\d{2}):(\d{2}):(\d{2})/);
+  if (!match) return null;
+  const [, y, mo, d, h, mi, s] = match;
+  const date = new Date(Number(y), Number(mo) - 1, Number(d), Number(h), Number(mi), Number(s));
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function findApp1(view: DataView): number | null {
+  if (view.getUint16(0) !== JPEG_SOI) return null;
+
+  let offset = 2;
+  while (offset < view.byteLength - 4) {
+    const marker = view.getUint16(offset);
+    if ((marker & 0xff00) !== 0xff00) break; // not a marker, bail out
+    const segmentLength = view.getUint16(offset + 2);
+
+    if (marker === APP1_MARKER) {
+      const headerText = String.fromCharCode(
+        ...new Uint8Array(view.buffer, view.byteOffset + offset + 4, EXIF_HEADER.length)
+      );
+      if (headerText === EXIF_HEADER) return offset + 4 + EXIF_HEADER.length;
+    }
+
+    if (marker === 0xffda) break; // start of scan - no more metadata segments follow
+    offset += 2 + segmentLength;
+  }
+  return null;
+}
+
+export async function parseJpegExif(file: File): Promise<PhotoMetadata> {
+  const buffer = await file.arrayBuffer();
+  const view = new DataView(buffer);
+
+  const empty: PhotoMetadata = {
+    gps: null,
+    capturedAt: null,
+    deviceMake: null,
+    deviceModel: null,
+  };
+
+  const tiffStart = findApp1(view);
+  if (tiffStart === null) return empty;
+
+  const byteOrderMark = view.getUint16(tiffStart);
+  const littleEndian = byteOrderMark === 0x4949; // "II"
+  const reader = new TiffReader(view, littleEndian, tiffStart);
+
+  const firstIfdOffset = reader.u32(tiffStart + 4);
+  const ifd0 = reader.readIfd(firstIfdOffset);
+
+  const deviceMake = ifd0.has(TAG_MAKE) ? reader.readAscii(ifd0.get(TAG_MAKE)!) : null;
+  const deviceModel = ifd0.has(TAG_MODEL) ? reader.readAscii(ifd0.get(TAG_MODEL)!) : null;
+
+  let capturedAt: Date | null = null;
+  if (ifd0.has(TAG_EXIF_IFD_POINTER)) {
+    const exifIfd = reader.readIfd(reader.u32(ifd0.get(TAG_EXIF_IFD_POINTER)!.valueOffset));
+    const dateEntry = exifIfd.get(TAG_DATETIME_ORIGINAL) ?? exifIfd.get(TAG_DATETIME);
+    if (dateEntry) capturedAt = parseExifDate(reader.readAscii(dateEntry));
+  }
+  if (!capturedAt && ifd0.has(TAG_DATETIME)) {
+    capturedAt = parseExifDate(reader.readAscii(ifd0.get(TAG_DATETIME)!));
+  }
+
+  let gps: PhotoMetadata["gps"] = null;
+  if (ifd0.has(TAG_GPS_IFD_POINTER)) {
+    const gpsIfd = reader.readIfd(reader.u32(ifd0.get(TAG_GPS_IFD_POINTER)!.valueOffset));
+    const latEntry = gpsIfd.get(TAG_GPS_LAT);
+    const lonEntry = gpsIfd.get(TAG_GPS_LON);
+
+    if (latEntry && lonEntry) {
+      const latRef = gpsIfd.has(TAG_GPS_LAT_REF)
+        ? reader.readAscii({ count: 2, valueOffset: gpsIfd.get(TAG_GPS_LAT_REF)!.valueOffset })
+        : "N";
+      const lonRef = gpsIfd.has(TAG_GPS_LON_REF)
+        ? reader.readAscii({ count: 2, valueOffset: gpsIfd.get(TAG_GPS_LON_REF)!.valueOffset })
+        : "E";
+
+      const latitude = reader.readGpsCoordinate(latEntry) * (latRef === "S" ? -1 : 1);
+      const longitude = reader.readGpsCoordinate(lonEntry) * (lonRef === "W" ? -1 : 1);
+
+      let altitude: number | undefined;
+      if (gpsIfd.has(TAG_GPS_ALTITUDE)) {
+        const altEntry = gpsIfd.get(TAG_GPS_ALTITUDE)!;
+        const altOffset = tiffStart + reader.u32(altEntry.valueOffset);
+        altitude = reader.readRational(altOffset);
+        const belowSeaLevel = gpsIfd.has(TAG_GPS_ALTITUDE_REF)
+          ? reader.readByteOrShort(gpsIfd.get(TAG_GPS_ALTITUDE_REF)!) === 1
+          : false;
+        if (belowSeaLevel) altitude *= -1;
+      }
+
+      gps = { latitude, longitude, altitude };
+    }
+  }
+
+  return { gps, capturedAt, deviceMake, deviceModel };
+}

--- a/lib/exif/format.ts
+++ b/lib/exif/format.ts
@@ -1,0 +1,18 @@
+import type { GpsCoordinates } from "./types";
+
+export function formatCoordinates(gps: GpsCoordinates): string {
+  const lat = `${Math.abs(gps.latitude).toFixed(5)}\u00b0${gps.latitude >= 0 ? "N" : "S"}`;
+  const lon = `${Math.abs(gps.longitude).toFixed(5)}\u00b0${gps.longitude >= 0 ? "E" : "W"}`;
+  return `${lat}, ${lon}`;
+}
+
+export function formatAltitude(meters: number): string {
+  return `${Math.round(meters)} m elevation`;
+}
+
+export function formatCapturedAt(date: Date): string {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}

--- a/lib/exif/index.ts
+++ b/lib/exif/index.ts
@@ -1,0 +1,5 @@
+export { PhotoMetadataModal } from "./PhotoMetadataModal";
+export type { PhotoMetadataModalProps } from "./PhotoMetadataModal";
+export { useExifData } from "./useExifData";
+export { parseJpegExif } from "./exifParser";
+export type { PhotoMetadata, GpsCoordinates, ExtractionStatus, ExifParser } from "./types";

--- a/lib/exif/types.ts
+++ b/lib/exif/types.ts
@@ -1,0 +1,30 @@
+export interface GpsCoordinates {
+  latitude: number;
+  longitude: number;
+  /** Meters above sea level, when the device recorded one. */
+  altitude?: number;
+}
+
+export interface PhotoMetadata {
+  gps: GpsCoordinates | null;
+  /** When the shutter fired, read from EXIF DateTimeOriginal (falls back to DateTime). */
+  capturedAt: Date | null;
+  deviceMake: string | null;
+  deviceModel: string | null;
+}
+
+export type ExtractionStatus =
+  | "idle"
+  | "reading"
+  | "success"
+  | "no-metadata"
+  | "error";
+
+export interface ExtractionResult {
+  status: ExtractionStatus;
+  metadata: PhotoMetadata | null;
+  error: string | null;
+}
+
+/** Injectable so tests (and future formats) can swap the extraction strategy. */
+export type ExifParser = (file: File) => Promise<PhotoMetadata>;


### PR DESCRIPTION
## Summary

Adds a client-side EXIF metadata preview modal that shows GPS location, capture timestamp, and device info before a planter submits a tree photo, so they can catch a missing-location or wrong-photo issue before it goes into the verification queue instead of after.

## Related Issue

Closes #843

## What Was Implemented

- [x] Dependency-free EXIF parser (`exifParser.ts`) that reads JPEG's APP1/EXIF segment directly — no external library, keeps the client bundle small
- [x] `useExifData` hook wrapping extraction with idle/reading/success/no-metadata/error states, plus a `retry()` for transient failures
- [x] `PhotoMetadataModal` component displaying GPS coordinates (+ altitude when present), capture timestamp, and device make/model
- [x] Thumbnail preview wrapped in an error boundary so a corrupt image can't take down the whole modal
- [x] Missing GPS data is treated as a warning, not a blocker — submission stays available with a note that manual review may follow
- [x] Full keyboard accessibility: focus moves to the dialog on open, Tab/Shift+Tab wraps within it, Escape closes it, body scroll locks while open
- [x] Responsive: bottom sheet on mobile, centered modal on larger viewports
- [x] Styled entirely with existing `stellar-navy` / `stellar-green` / `stellar-blue` tokens (opacity modifiers for tints, no new colors), plus Tailwind's default `red` scale for hard error states only
- [x] Unit tests for the parser (byte-level EXIF fixture, hemisphere sign flips, missing-EXIF fallback) and the modal (loading/success/no-metadata/error states, confirm/retry callbacks, focus trap, scroll lock)

## Implementation Details

- The EXIF parser only reads the fields the UI displays (Make, Model, DateTimeOriginal, GPS lat/lon/altitude) rather than the full EXIF spec, to keep it small and dependency-free.
- **Known limitation:** JPEG only. HEIC (iPhone's default capture format unless "Most Compatible" is on) isn't parsed — it falls through gracefully to the "no GPS data" warning state rather than erroring, but a HEIC-aware parser is a natural follow-up if planters report seeing that state often.
- No `tailwind.config.js` changes — the component intentionally sticks to the three documented brand tokens plus Tailwind's opacity-modifier syntax rather than introducing new design tokens, so it stays inside the existing design system as-is.
- The extraction hook keeps the parser reference in a ref rather than a `useEffect` dependency, so a caller passing a non-memoized parser inline doesn't cause extraction to re-run on every parent re-render — only when the `File` itself changes.
- All EXIF reading happens client-side; the file is never sent anywhere for this preview step.

## Screenshots / Recordings

<!-- Attach your screen recording here before opening the PR -->

## How to Test

1. Checkout this branch
2. Run `pnpm dev`
3. Navigate to the tree photo upload flow
4. Select a JPEG with embedded GPS/EXIF data (e.g. a phone photo with location services on) — confirm the modal shows GPS coordinates (tap the location row context to verify it matches the actual capture location), timestamp, and device make/model
5. Select a photo with no EXIF data (e.g. a screenshot) — confirm it shows the "No GPS data found" state with the manual-review note, and that "Confirm & submit" is still enabled
6. Confirm keyboard-only navigation: Tab/Shift+Tab stays inside the modal, Escape closes it
7. Resize the viewport mobile → desktop — confirm the modal switches from a bottom sheet to a centered dialog
8. Run `pnpm test`, `pnpm lint`, `pnpm build` — all should pass
