### PR TITLE
[Webhook] Add planter event types and emitter functions

### DIFF
--- a/lib/webhook/events.ts
+++ b/lib/webhook/events.ts
@@ -5,7 +5,14 @@
 
 import { getPool } from '@/lib/db/client';
 import { dispatchEvent } from './dispatch';
-import type { MilestonePayoutApprovedPayload, WebhookDeliveryRow } from './types';
+import type {
+  MilestonePayoutApprovedPayload,
+  PlanterTreeRegisteredPayload,
+  PlanterTreeVerifiedPayload,
+  PlanterTreeHealthUpdatedPayload,
+  PlanterMilestoneClaimedPayload,
+  WebhookDeliveryRow,
+} from './types';
 
 /**
  * Emit `milestone.payout.approved` after a milestone escrow release is confirmed
@@ -26,6 +33,54 @@ export async function emitMilestonePayoutApproved(
     });
   } catch (err) {
     console.error('[webhook] failed to emit milestone.payout.approved', err);
+    return [];
+  }
+}
+
+export async function emitPlanterTreeRegistered(
+  payload: PlanterTreeRegisteredPayload
+): Promise<WebhookDeliveryRow[]> {
+  try {
+    const pool = getPool();
+    return await dispatchEvent(pool, 'planter.tree.registered', { ...payload });
+  } catch (err) {
+    console.error('[webhook] failed to emit planter.tree.registered', err);
+    return [];
+  }
+}
+
+export async function emitPlanterTreeVerified(
+  payload: PlanterTreeVerifiedPayload
+): Promise<WebhookDeliveryRow[]> {
+  try {
+    const pool = getPool();
+    return await dispatchEvent(pool, 'planter.tree.verified', { ...payload });
+  } catch (err) {
+    console.error('[webhook] failed to emit planter.tree.verified', err);
+    return [];
+  }
+}
+
+export async function emitPlanterTreeHealthUpdated(
+  payload: PlanterTreeHealthUpdatedPayload
+): Promise<WebhookDeliveryRow[]> {
+  try {
+    const pool = getPool();
+    return await dispatchEvent(pool, 'planter.tree.health.updated', { ...payload });
+  } catch (err) {
+    console.error('[webhook] failed to emit planter.tree.health.updated', err);
+    return [];
+  }
+}
+
+export async function emitPlanterMilestoneClaimed(
+  payload: PlanterMilestoneClaimedPayload
+): Promise<WebhookDeliveryRow[]> {
+  try {
+    const pool = getPool();
+    return await dispatchEvent(pool, 'planter.milestone.claimed', { ...payload });
+  } catch (err) {
+    console.error('[webhook] failed to emit planter.milestone.claimed', err);
     return [];
   }
 }

--- a/lib/webhook/types.ts
+++ b/lib/webhook/types.ts
@@ -10,7 +10,13 @@
  * Logical events the platform can dispatch. Kept as a const tuple so the union
  * type and a runtime list stay in sync.
  */
-export const WEBHOOK_EVENT_TYPES = ['milestone.payout.approved'] as const;
+export const WEBHOOK_EVENT_TYPES = [
+  'milestone.payout.approved',
+  'planter.tree.registered',
+  'planter.tree.verified',
+  'planter.tree.health.updated',
+  'planter.milestone.claimed',
+] as const;
 
 export type DispatchEventType = (typeof WEBHOOK_EVENT_TYPES)[number];
 
@@ -63,6 +69,65 @@ export interface MilestonePayoutApprovedPayload {
   transactionHash: string;
   explorerUrl: string;
   approvedAt: string; // ISO 8601
+}
+
+/**
+ * Payload sent for `planter.tree.registered` — emitted when a new tree is
+ * registered and an on-chain mint event is detected.
+ */
+export interface PlanterTreeRegisteredPayload {
+  planterWallet: string;
+  treeId: number;
+  species: string;
+  region: string;
+  transactionHash: string;
+  explorerUrl: string;
+  registeredAt: string; // ISO 8601
+}
+
+/**
+ * Payload sent for `planter.tree.verified` — emitted when a verifier approves
+ * or rejects a tree planting during field verification.
+ */
+export interface PlanterTreeVerifiedPayload {
+  planterWallet: string;
+  treeId: number;
+  verifierWallet: string;
+  approved: boolean;
+  notesHash: string | null;
+  transactionHash: string;
+  explorerUrl: string;
+  verifiedAt: string; // ISO 8601
+}
+
+/**
+ * Payload sent for `planter.tree.health.updated` — emitted when a tree's
+ * health/survival status changes via the state machine.
+ */
+export interface PlanterTreeHealthUpdatedPayload {
+  planterWallet: string;
+  treeId: number;
+  verifierWallet: string;
+  previousHealth: string | null;
+  newHealth: string;
+  transactionHash: string;
+  explorerUrl: string;
+  updatedAt: string; // ISO 8601
+}
+
+/**
+ * Payload sent for `planter.milestone.claimed` — emitted when a sponsor
+ * claims a carbon credit milestone for a tree.
+ */
+export interface PlanterMilestoneClaimedPayload {
+  planterWallet: string;
+  treeId: number;
+  sponsorWallet: string;
+  milestoneYears: number;
+  co2CreditsKg: number;
+  transactionHash: string;
+  explorerUrl: string;
+  claimedAt: string; // ISO 8601
 }
 
 /** Discriminated envelope POSTed to planter backends. */


### PR DESCRIPTION
## Overview

This PR extends the existing webhook dispatch system with planter-specific event types and emitter functions. Previously, only `milestone.payout.approved` was supported as a webhook event. This PR adds four new event types covering the full tree lifecycle: registration, field verification, health/survival updates, and carbon credit milestone claims. These events enable planter backend systems to receive real-time notifications about their trees without polling the Stellar blockchain.

## Related Issue

Closes #822

## Changes

### 📝 Type Definitions
**[MODIFY] lib/webhook/types.ts**

**Updated: `WEBHOOK_EVENT_TYPES`**
- Extended from 1 event type to 5:
  - `milestone.payout.approved` (existing)
  - `planter.tree.registered` (new)
  - `planter.tree.verified` (new)
  - `planter.tree.health.updated` (new)
  - `planter.milestone.claimed` (new)

**New interfaces:**

| Interface | Fields | Description |
|-----------|--------|-------------|
| `PlanterTreeRegisteredPayload` | planterWallet, treeId, species, region, transactionHash, explorerUrl, registeredAt | Emitted when a new tree is minted on-chain |
| `PlanterTreeVerifiedPayload` | planterWallet, treeId, verifierWallet, approved, notesHash, transactionHash, explorerUrl, verifiedAt | Emitted when a verifier approves or rejects a tree |
| `PlanterTreeHealthUpdatedPayload` | planterWallet, treeId, verifierWallet, previousHealth, newHealth, transactionHash, explorerUrl, updatedAt | Emitted when a trees health state transitions |
| `PlanterMilestoneClaimedPayload` | planterWallet, treeId, sponsorWallet, milestoneYears, co2CreditsKg, transactionHash, explorerUrl, claimedAt | Emitted when carbon credits are claimed for a milestone |

### 📨 Event Emitters
**[MODIFY] lib/webhook/events.ts**

**Updated imports** — now imports all 5 payload types from `./types`

**4 new emitter functions:**

| Function | Event Type | Triggered By |
|----------|-----------|--------------|
| `emitPlanterTreeRegistered()` | `planter.tree.registered` | Contract event listener detecting TreeMinted events |
| `emitPlanterTreeVerified()` | `planter.tree.verified` | Contract event listener detecting TreeVerified/TreeRejected events |
| `emitPlanterTreeHealthUpdated()` | `planter.tree.health.updated` | Contract event listener detecting TreeHealthUpdated events |
| `emitPlanterMilestoneClaimed()` | `planter.milestone.claimed` | Contract event listener detecting MilestoneClaimed events |

Each function:
- Accepts its typed payload interface
- Calls `dispatchEvent()` to fan-out to all matching active subscriptions
- Is wrapped in try/catch — errors are logged and swallowed (best-effort, never fail the caller)
- Returns `Promise<WebhookDeliveryRow[]>` (empty array on failure)
- Follows the exact same pattern as the existing `emitMilestonePayoutApproved()`

## Verification Results

```bash
npx tsc --noEmit --pretty 2>&1 | grep -E "error|Error" || echo "No TypeScript errors"

# Expected: zero type errors (new types are properly exported and imported)
```

## Acceptance Criteria

| # | Requirement | Status |
|---|-------------|--------|
| 1 | New event types are added to the WEBHOOK_EVENT_TYPES tuple | ✅ |
| 2 | TypeScript unions automatically include new types | ✅ (via `as const`) |
| 3 | Each event type has a typed payload interface | ✅ |
| 4 | Each event type has a best-effort emitter function | ✅ |
| 5 | Existing milestone.payout.approved is unchanged | ✅ |
| 6 | All emitter functions handle errors gracefully (fire-and-forget) | ✅ |
| 7 | Subscription query logic supports new events | ✅ (existing SQL handles them) |

## Integration Guide

To subscribe to a planter event, insert a row into `webhook_subscriptions`:
```sql
INSERT INTO webhook_subscriptions (planter_id, url, secret, event_types)
VALUES (123, https://planter-backend.example.com/webhooks, whsec_..., 
        ARRAY[planter.tree.registered, planter.tree.verified]);
```

To wire an emitter to an on-chain event listener:
```typescript
import { emitPlanterTreeRegistered } from @/lib/webhook/events;

// Inside your contract event listener:
await emitPlanterTreeRegistered({
  planterWallet: event.planter.toString(),
  treeId: Number(event.tree_id),
  species: event.species.toString(),
  region: event.region.toString(),
  transactionHash: txHash,
  explorerUrl: `https://stellar.expert/explorer/testnet/tx/${txHash}`,
  registeredAt: new Date().toISOString(),
});
```

Closes #822