### PR TITLE
[NFT Certificate] Enhance merging with batch size limits and duplicate detection

### DIFF
--- a/contracts/nft-certificate/src/lib.rs
+++ b/contracts/nft-certificate/src/lib.rs
@@ -41,6 +41,11 @@ pub struct Token {
     pub metadata: CertificateMetadata,
 }
 
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/// Maximum number of certificates that can be merged in a single merge() call.
+const MAX_MERGE_BATCH_SIZE: u32 = 100;
+
 // ── Contract ──────────────────────────────────────────────────────────────────
 
 #[contract]
@@ -140,6 +145,11 @@ impl NftCertificate {
             panic_with_error!(&env, HarvestaError::Co2MustBePositive);
         }
 
+        // Batch size limit prevents gas bomb DoS attacks
+        if token_ids.len() > (MAX_MERGE_BATCH_SIZE as u64) {
+            panic_with_error!(&env, HarvestaError::BatchTooLarge);
+        }
+
         // Check if new token ID already exists
         if env.storage().instance().has(&new_token_id) {
             panic_with_error!(&env, NftError::TokenAlreadyMinted);
@@ -147,6 +157,18 @@ impl NftCertificate {
 
         let mut total_tree_count = 0i128;
         let mut total_co2_offset = 0i128;
+
+        // Verify no duplicate token IDs in the merge list
+        {
+            let mut seen_ids = soroban_sdk::Vec::new(&env);
+            for i in 0..token_ids.len() {
+                let tid = token_ids.get(i).unwrap();
+                if seen_ids.contains(&tid) {
+                    panic_with_error!(&env, HarvestaError::AmountMustBePositive);
+                }
+                seen_ids.push_back(tid);
+            }
+        }
 
         // Verify ownership and aggregate metadata from all certificates
         for i in 0..token_ids.len() {
@@ -509,5 +531,66 @@ mod tests {
 
         let uri = client.token_uri(&1);
         assert!(uri.len() > 0);
+    }
+
+    // ── Merge Enhancement Tests ──────────────────────────────────────────────
+    #[test]
+    fn test_merge_duplicate_token_ids_rejected() {
+        let (env, _, client) = setup();
+        let owner = Address::generate(&env);
+        let meta1 = metadata(&env, 50, 2400);
+        client.mint(&owner.clone(), &1, &meta1);
+        let merged_meta = metadata(&env, 50, 2400);
+        let token_ids = Vec::from_array(&env, [1, 1]);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.merge(&owner, &token_ids, &3, &merged_meta);
+        }));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_merge_six_certificates() {
+        let (env, _, client) = setup();
+        let owner = Address::generate(&env);
+        for i in 0..6 {
+            let meta = metadata(&env, 10, 480);
+            client.mint(&owner.clone(), &(i + 1), &meta);
+        }
+        let merged_meta = metadata(&env, 60, 2880);
+        let mut token_ids = Vec::new(&env);
+        for i in 0..6 {
+            token_ids.push_back(i + 1);
+        }
+        client.merge(&owner, &token_ids, &100, &merged_meta);
+        let token = client.get_token(&100).unwrap();
+        assert_eq!(token.metadata.tree_count, 60);
+        assert_eq!(token.metadata.co2_offset_kg, 2880);
+        assert_eq!(client.total_supply(), 1);
+    }
+
+    #[test]
+    fn test_get_token_returns_none_for_burned() {
+        let (env, _, client) = setup();
+        let owner = Address::generate(&env);
+        let meta = metadata(&env, 50, 2400);
+        client.mint(&owner.clone(), &1, &meta);
+        assert!(client.get_token(&1).is_some());
+        let merged_meta = metadata(&env, 50, 2400);
+        let token_ids = Vec::from_array(&env, [1]);
+        client.merge(&owner, &token_ids, &2, &merged_meta);
+        assert!(client.get_token(&1).is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #3)")]
+    fn test_merge_with_wrong_owner_rejected() {
+        let (env, _, client) = setup();
+        let owner = Address::generate(&env);
+        let other = Address::generate(&env);
+        let meta1 = metadata(&env, 50, 2400);
+        client.mint(&owner, &1, &meta1);
+        let merged_meta = metadata(&env, 50, 2400);
+        let token_ids = Vec::from_array(&env, [1]);
+        client.merge(&other, &token_ids, &2, &merged_meta);
     }
 }


### PR DESCRIPTION
## Overview

This PR enhances the NFT Certificate `merge()` function with security-hardened guards and comprehensive test coverage. The merge function allows consolidating multiple smaller carbon-certificate NFTs into a single larger certificate by burning the originals and minting a consolidated one. The enhancements address two attack vectors: (1) gas-bomb DoS through excessively large batch sizes, and (2) double-burning the same token via duplicate entries in the merge list.

## Related Issue

Closes #778

## Changes

### 📦 Contract Changes
**[MODIFY] contracts/nft-certificate/src/lib.rs**

**New constant: `MAX_MERGE_BATCH_SIZE = 100`**
- Sets an upper bound on the number of certificates that can be merged in a single call
- Prevents gas-bomb DoS attacks where an attacker merges thousands of dust certificates at once
- Keeps per-transaction gas costs predictable and bounded
- If exceeded, panics with `HarvestaError::BatchTooLarge`

**New: Duplicate token ID detection**
- Before iterating the merge list, the contract builds a `seen_ids` Vec and checks each token ID against it
- If a duplicate ID is found, panics with `HarvestaError::AmountMustBePositive`
- Prevents double-burning the same token (which would give the caller a net loss of 1 certificate without burning an actual second one)
- O(n) space, O(n²) time — acceptable for n ≤ 100 (max 10K comparisons)

### ✅ New Tests

| Test | Description |
|------|-------------|
| `test_merge_duplicate_token_ids_rejected` | Verifies merging [1, 1] panics due to duplicate detection |
| `test_merge_six_certificates` | Verifies merging 6 certificates (all same metadata) succeeds with correct aggregated values |
| `test_get_token_returns_none_for_burned` | Verifies original tokens are properly burned (not just transferred) after merge |
| `test_merge_with_wrong_owner_rejected` | Verifies non-owner cannot merge another addresss tokens |

## Verification Results

```bash
cd contracts/nft-certificate
cargo test --lib

# Expected output includes:
test tests::test_merge_two_certificates ... ok
test tests::test_merge_duplicate_token_ids_rejected ... ok
test tests::test_merge_six_certificates ... ok
test tests::test_get_token_returns_none_for_burned ... ok
test tests::test_merge_with_wrong_owner_rejected ... ok
```

## Acceptance Criteria

| # | Requirement | Status |
|---|-------------|--------|
| 1 | Merge rejects more than 100 certificates in a single call | ✅ `BatchTooLarge` |
| 2 | Merge rejects duplicate token IDs in the input list | ✅ `AmountMustBePositive` |
| 3 | Merged certificate has correct aggregated tree_count and co2_offset_kg | ✅ |
| 4 | Original tokens are burned (get_token returns None) after merge | ✅ |
| 5 | Non-owners cannot merge tokens they do not control | ✅ |
| 6 | Merged event is emitted with correct payload | ✅ |
| 7 | Metadata mismatch (tree_count or co2_offset) is rejected | ✅ |
| 8 | Total supply is correctly updated (n burned + 1 minted) | ✅ |

## Edge Cases & Notes

- **Duplicate detection is identity-based, not value-based**: Two tokens with identical metadata but different IDs are treated as distinct and merged correctly. Only the exact same token ID appearing twice is rejected.
- **Batch limit is a hard upper bound**: Setting MAX_MERGE_BATCH_SIZE to 100 is generous for practical use. Most merges will involve 2-10 certificates. The limit exists as a safety net against abuse.
- **Metadata verification unchanged**: The merge function still requires the caller to provide the correct aggregated metadata (sum of tree_count and sum of co2_offset_kg). This ensures the caller is aware of what they are creating.

Closes #778