### PR TITLE
docs(api): document public API rate limits and tier pricing

### DIFF
--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -1,0 +1,44 @@
+# Public API — Rate Limits & Pricing
+
+## Overview
+
+The FarmCredit Public API lets external applications read and submit
+carbon-credit, planting, and transaction data. Access is controlled by a
+tiered rate-limiting policy so free projects can experiment while high-volume
+integrations can scale.
+
+All limits are measured as **requests per calendar day** per API key.
+
+## Rate Limit Tiers
+
+| Tier            | Requests / day | Price       |
+| --------------- | -------------- | ----------- |
+| **Free**        | 100            | $0 / month  |
+| **Paid Tier 1** | 1,000          | $10 / month |
+| **Paid Tier 2** | 10,000         | $50 / month |
+
+### Free
+
+- **100 requests/day**
+- **$0/month**
+- Ideal for evaluation, local development, and low-traffic prototypes.
+
+### Paid Tier 1
+
+- **1,000 requests/day**
+- **$10/month**
+- Suitable for small production integrations and growing applications.
+
+### Paid Tier 2
+
+- **10,000 requests/day**
+- **$50/month**
+- Designed for high-volume partners and production workloads.
+
+## Notes
+
+- Rate limits are enforced per API key on a rolling calendar-day window.
+- When a tier's daily limit is reached, the API responds with HTTP `429 Too
+Many Requests` until the window resets.
+- Upgrading to a paid tier increases the daily request allowance immediately
+  upon activation.


### PR DESCRIPTION
## Description

### Summary

Documents the Public API rate limits and corresponding tier-based pricing so users can clearly understand the available usage limits and subscription options.

### Changes

* Documented the **Free tier**:

  * 100 requests/day
  * $0/month
* Documented **Paid Tier 1**:

  * 1,000 requests/day
  * $10/month
* Documented **Paid Tier 2**:

  * 10,000 requests/day
  * $50/month
* Added clear documentation for the relationship between API usage limits and pricing.

### Testing

* Reviewed the updated documentation for accuracy and consistency.
* Confirmed all documented request limits and pricing match the issue requirements.

### Issue

Closes #1019
