### PR TITLE
chore(docs): document branch naming, commit format, and PR requirements

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,3 +41,6 @@ Closes #
 - [ ] New components follow the atomic design pattern (atoms → molecules → organisms)
 - [ ] UI changes are responsive and tested on mobile viewports
 - [ ] I have added screenshots/recordings for UI changes
+ - [ ] Branch name follows conventions (`feature/`, `bugfix/`, `chore/`, `docs/`, `hotfix/`)
+ - [ ] PR links to an issue (`Closes #<number>`) when applicable
+ - [ ] Screen recording attached for UI or feature changes

--- a/COMMIT_MESSAGE.md
+++ b/COMMIT_MESSAGE.md
@@ -1,4 +1,32 @@
+Commit message format
+
+This repository follows the Conventional Commits spec. Use the following template for commit messages:
+
+```
+<type>(<scope>): <short description>
+
+[optional body — explain WHY and HOW]
+
+[optional footer — breaking changes or issue refs]
+```
+
+Common types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`
+
+Configure your local repo to use the template (optional):
+
+```bash
+git config commit.template .gitmessage
+```
+
+Commitlint is configured to enforce this format via the `commit-msg` Husky hook.
+
+Example:
+
+```
 perf(contracts): optimize storage operations in hot paths to < 0.10 per tx
+
+```
+
 
 Profiled and optimized storage reads/writes in critical transaction paths:
 - donate(): 71% reduction (0.35 → 0.10) ✅

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -481,13 +481,29 @@ git add -p
 ```bash
 git checkout main
 git pull origin main
-git checkout -b feat/<issue-number>-<short-description>
+git checkout -b feature/<issue-number>-<short-description>
 ```
 
-**Branch naming:**
-- `feat/42-wallet-connection-modal`
-- `fix/78-donation-validation-bug`
-- `docs/107-contributor-guide`
+**Branch naming (required):**
+
+Use the following branch prefixes to make intent clear and simplify reviews and automation:
+
+- `feature/` — new features and UI flows (maps to commit type `feat`)
+- `bugfix/` — bug fixes and regressions (maps to commit type `fix`)
+- `chore/` — maintenance, tooling, and non-functional work (maps to commit type `chore`)
+- `docs/` — documentation-only changes
+- `hotfix/` — urgent fixes that must go directly to production
+
+Examples:
+
+- `feature/42-wallet-connection-modal`
+- `bugfix/78-donation-validation`
+- `chore/107-deps-upgrade`
+
+Notes:
+- Branch prefixes are required for feature branches (do not use raw issue numbers alone).
+- Keep branch names short, use kebab-case for the descriptive part, and include the issue number when relevant.
+- Branch naming is independent of commit message types; commits should still follow Conventional Commits (`feat:`, `fix:`, `chore:`, etc.).
 
 ### Before Submitting
 


### PR DESCRIPTION
Document branch naming (feature/bugfix/chore/docs/hotfix), commit message template (Conventional Commits), and update PR checklist.
What Was Implemented
Updated [CONTRIBUTING.md](vscode-file://vscode-app/c:/Users/Administrator/AppData/Local/Programs/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with branch naming guidance and examples
Updated [PULL_REQUEST_TEMPLATE.md](vscode-file://vscode-app/c:/Users/Administrator/AppData/Local/Programs/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html) checklist to require branch naming, linked issue, and screen recording
Added commit message guidance to [COMMIT_MESSAGE.md](vscode-file://vscode-app/c:/Users/Administrator/AppData/Local/Programs/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
How to Test
Review changed files: [CONTRIBUTING.md](vscode-file://vscode-app/c:/Users/Administrator/AppData/Local/Programs/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [PULL_REQUEST_TEMPLATE.md](vscode-file://vscode-app/c:/Users/Administrator/AppData/Local/Programs/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [COMMIT_MESSAGE.md](vscode-file://vscode-app/c:/Users/Administrator/AppData/Local/Programs/Microsoft%20VS%20Code/7e7950df89/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Confirm the commit-msg hook rejects non-Conventional messages locally (if hooks installed)
Create a test branch with the new naming convention and open a PR to verify the template/checklist appear

closes #1002