### PR TITLE
chore(config): include Stellar Horizon connectivity in /healthz

### DIFF
--- a/app/api/healthz/route.ts
+++ b/app/api/healthz/route.ts
@@ -1,6 +1,36 @@
 import { NextResponse } from 'next/server';
 import { getPool } from '@/lib/db/client';
 import { RpcHealthMonitor } from '@/lib/monitor/rpc-health';
+import { networkConfig } from '@/lib/config/network';
+
+const HORIZON_PING_TIMEOUT_MS = 5_000;
+
+async function checkHorizon(): Promise<{
+  ok: boolean;
+  latencyMs: number;
+  url: string;
+  error?: string;
+}> {
+  const url = networkConfig.horizonUrl;
+  if (!url) {
+    return { ok: false, latencyMs: 0, url: '', error: 'NEXT_PUBLIC_HORIZON_URL not configured' };
+  }
+
+  const start = Date.now();
+  try {
+    const res = await fetch(`${url}/`, {
+      method: 'HEAD',
+      signal: AbortSignal.timeout(HORIZON_PING_TIMEOUT_MS),
+    });
+    const latencyMs = Date.now() - start;
+    const ok = res.ok || res.status < 500;
+    return ok
+      ? { ok: true, latencyMs, url }
+      : { ok: false, latencyMs, url, error: `Horizon returned HTTP ${res.status}` };
+  } catch (err) {
+    return { ok: false, latencyMs: Date.now() - start, url, error: String(err) };
+  }
+}
 
 async function checkDb(): Promise<{ ok: boolean; latencyMs: number; error?: string }> {
   const start = Date.now();
@@ -49,16 +79,16 @@ async function checkRpcNodes(): Promise<{
 }
 
 export async function GET() {
-  const [db, rpc] = await Promise.all([checkDb(), checkRpcNodes()]);
+  const [db, rpc, horizon] = await Promise.all([checkDb(), checkRpcNodes(), checkHorizon()]);
 
-  const allOk = db.ok && rpc.ok;
+  const allOk = db.ok && rpc.ok && horizon.ok;
   const status = allOk ? 200 : 503;
 
   return NextResponse.json(
     {
       status: allOk ? 'ok' : 'degraded',
       timestamp: new Date().toISOString(),
-      checks: { db, rpc },
+      checks: { db, rpc, horizon },
     },
     { status }
   );


### PR DESCRIPTION
## Summary

Extend the `/healthz` readiness probe to explicitly check Stellar Horizon server reachability. Previously, the endpoint only checked database and RPC node health, but did not verify that the Horizon server configured via `NEXT_PUBLIC_HORIZON_URL` was actually reachable.

## Changes

- **New `checkHorizon()` function** in `app/api/healthz/route.ts`:
  - Reads the Horizon URL from `networkConfig.horizonUrl` (`NEXT_PUBLIC_HORIZON_URL`)
  - Sends a `HEAD` request to the Horizon root endpoint with a 5-second timeout
  - Returns `ok: false` if the URL is not configured, the request fails, or Horizon returns a 5xx status
  - Includes latency measurement and error details in the response

- **Updated `GET` handler**:
  - Runs `checkHorizon()` in parallel with existing `checkDb()` and `checkRpcNodes()`
  - Returns **503** if Horizon is unreachable (along with DB/RPC failures)
  - Response now includes a `horizon` key in the `checks` object

## Example Response

```json
{
  status: ok,
  timestamp: 2026-08-26T...,
  checks: {
    db: { ok: true, latencyMs: 2 },
    rpc: { ok: true, nodes: [...], bestNode: ... },
    horizon: { ok: true, latencyMs: 120, url: https://horizon-testnet.stellar.org }
  }
}
```

## Testing

- Verified that `npx eslint app/api/healthz/route.ts` passes clean
- No typecheck regressions introduced (pre-existing errors in other files are unchanged)

Closes #1001