### PR TITLE
fix(backend): GPS validation fails for regions crossing date line

### DIFF
--- a/lib/geo/distance.ts
+++ b/lib/geo/distance.ts
@@ -12,8 +12,20 @@ export function getDistance(lat1: number, lon1: number, lat2: number, lon2: numb
   const R = 6371e3; // Earth radius in meters
   const toRadian = (angle: number) => (angle * Math.PI) / 180;
 
+  // Normalize longitudes to handle date line crossing
+  let normalizedLon1 = lon1;
+  let normalizedLon2 = lon2;
+  while (normalizedLon1 > 180) normalizedLon1 -= 360;
+  while (normalizedLon1 < -180) normalizedLon1 += 360;
+  while (normalizedLon2 > 180) normalizedLon2 -= 360;
+  while (normalizedLon2 < -180) normalizedLon2 += 360;
+
   const dLat = toRadian(lat2 - lat1);
-  const dLon = toRadian(lon2 - lon1);
+  let dLon = toRadian(normalizedLon2 - normalizedLon1);
+
+  // Ensure we take the shortest path across the date line
+  if (dLon > Math.PI) dLon -= 2 * Math.PI;
+  if (dLon < -Math.PI) dLon += 2 * Math.PI;
 
   const a =
     Math.sin(dLat / 2) * Math.sin(dLat / 2) +

--- a/lib/geo/polygon.test.ts
+++ b/lib/geo/polygon.test.ts
@@ -1,5 +1,37 @@
 import { describe, expect, it } from 'vitest';
-import { checkRegionCoverage, containsPointInPolygon } from './polygon';
+import {
+  checkRegionCoverage,
+  containsPointInPolygon,
+  normalizeLng,
+  lngDelta,
+} from './polygon';
+
+describe('normalizeLng', () => {
+  it('normalizes longitudes within range', () => {
+    expect(normalizeLng(0)).toBe(0);
+    expect(normalizeLng(90)).toBe(90);
+    expect(normalizeLng(-90)).toBe(-90);
+  });
+
+  it('normalizes longitudes beyond ±180', () => {
+    expect(normalizeLng(181)).toBe(-179);
+    expect(normalizeLng(-181)).toBe(179);
+    expect(normalizeLng(360)).toBe(0);
+    expect(normalizeLng(-360)).toBe(0);
+    expect(normalizeLng(540)).toBe(180);
+    expect(normalizeLng(-540)).toBe(-180);
+  });
+});
+
+describe('lngDelta', () => {
+  it('calculates shortest delta considering wraparound', () => {
+    expect(lngDelta(179, -179)).toBe(2); // Short path across date line
+    expect(lngDelta(-179, 179)).toBe(-2);
+    expect(lngDelta(90, -90)).toBe(180);
+    expect(lngDelta(-90, 90)).toBe(-180);
+    expect(lngDelta(10, 20)).toBe(-10);
+  });
+});
 
 describe('containsPointInPolygon', () => {
   it('returns true for a point inside a simple polygon', () => {
@@ -12,6 +44,39 @@ describe('containsPointInPolygon', () => {
 
     expect(containsPointInPolygon(5, 5, polygon)).toBe(true);
     expect(containsPointInPolygon(11, 5, polygon)).toBe(false);
+  });
+
+  it('handles polygons crossing the date line', () => {
+    // Fiji polygon: spans from 177° to -178° (crosses date line)
+    const fijiPolygon = [
+      [-20.0, 177.0],
+      [-15.0, 177.0],
+      [-15.0, -178.0],
+      [-20.0, -178.0],
+    ] as [number, number][];
+
+    // Point inside Fiji (near Suva): lat=-18.1, lng=178.4
+    expect(containsPointInPolygon(-18.1, 178.4, fijiPolygon)).toBe(true);
+    // Point inside Fiji (near Nadi): lat=-17.8, lng=177.4
+    expect(containsPointInPolygon(-17.8, 177.4, fijiPolygon)).toBe(true);
+    // Point inside Fiji (near Labasa): lat=-16.4, lng=179.4
+    expect(containsPointInPolygon(-16.4, 179.4, fijiPolygon)).toBe(true);
+    // Point outside Fiji (in Australia)
+    expect(containsPointInPolygon(-33.9, 151.2, fijiPolygon)).toBe(false);
+  });
+
+  it('handles Tonga polygon', () => {
+    const tongaPolygon = [
+      [-23.0, -176.0],
+      [-15.0, -176.0],
+      [-15.0, -173.0],
+      [-23.0, -173.0],
+    ] as [number, number][];
+
+    // Point inside Tonga (near Nuku'alofa): lat=-21.2, lng=-175.2
+    expect(containsPointInPolygon(-21.2, -175.2, tongaPolygon)).toBe(true);
+    // Point outside Tonga
+    expect(containsPointInPolygon(-14.0, -175.0, tongaPolygon)).toBe(false);
   });
 });
 
@@ -29,5 +94,28 @@ describe('checkRegionCoverage', () => {
     expect(checkRegionCoverage({ latitude: 10.0, longitude: 2.0, regionCode: 'unknown' })).toBe(
       false
     );
+  });
+
+  it('matches Fiji region crossing the date line', () => {
+    // Inside Fiji
+    expect(
+      checkRegionCoverage({ latitude: -18.1, longitude: 178.4, regionCode: 'fiji' })
+    ).toBe(true);
+    // Outside Fiji
+    expect(
+      checkRegionCoverage({ latitude: -33.9, longitude: 151.2, regionCode: 'fiji' })
+    ).toBe(false);
+  });
+
+  it('matches Tonga region', () => {
+    expect(
+      checkRegionCoverage({ latitude: -21.2, longitude: -175.2, regionCode: 'tonga' })
+    ).toBe(true);
+  });
+
+  it('matches Samoa region', () => {
+    expect(
+      checkRegionCoverage({ latitude: -13.8, longitude: -172.0, regionCode: 'samoa' })
+    ).toBe(true);
   });
 });

--- a/lib/geo/polygon.ts
+++ b/lib/geo/polygon.ts
@@ -11,7 +11,53 @@ const REGION_POLYGONS: Record<string, [number, number][]> = {
     [14.0, 15.0],
     [4.0, 15.0],
   ],
+  'fiji': [
+    [-20.0, 177.0],
+    [-15.0, 177.0],
+    [-15.0, -178.0],
+    [-20.0, -178.0],
+  ],
+  'tonga': [
+    [-23.0, -176.0],
+    [-15.0, -176.0],
+    [-15.0, -173.0],
+    [-23.0, -173.0],
+  ],
+  'samoa': [
+    [-14.0, -173.0],
+    [-13.0, -173.0],
+    [-13.0, -171.0],
+    [-14.0, -171.0],
+  ],
 };
+
+/**
+ * Normalize longitude to the range [-180, 180].
+ * Handles wraparound for locations near the date line.
+ */
+export function normalizeLng(lng: number): number {
+  // Keep normalizing until within range
+  let normalized = lng;
+  while (normalized > 180) {
+    normalized -= 360;
+  }
+  while (normalized < -180) {
+    normalized += 360;
+  }
+  return normalized;
+}
+
+/**
+ * Calculate the shortest longitude distance considering wraparound.
+ * Returns the signed difference in the range [-180, 180].
+ */
+export function lngDelta(a: number, b: number): number {
+  const diff = a - b;
+  // Wrap to [-180, 180]
+  if (diff > 180) return diff - 360;
+  if (diff < -180) return diff + 360;
+  return diff;
+}
 
 export function containsPointInPolygon(
   latitude: number,
@@ -22,23 +68,21 @@ export function containsPointInPolygon(
     return false;
   }
 
+  // Normalize the input longitude
+  const normalizedLng = normalizeLng(longitude);
+
   let inside = false;
   for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
-    const [x1, y1] = polygon[i];
-    const [x2, y2] = polygon[j];
+    const [lat1, lng1] = polygon[i];
+    const [lat2, lng2] = polygon[j];
 
-    const onSegment =
-      y1 > longitude !== y2 > longitude &&
-      latitude < ((x2 - x1) * (longitude - y1)) / (y2 - y1) + x1;
+    // Calculate longitude delta considering date line wraparound
+    const dLng = lngDelta(lng2, lng1);
 
-    if (onSegment) {
-      inside = !inside;
-      continue;
-    }
-
+    // Ray casting algorithm adapted for date line crossings
     const crosses =
-      y1 > longitude !== y2 > longitude &&
-      latitude < ((x2 - x1) * (longitude - y1)) / (y2 - y1) + x1;
+      lat1 > normalizedLng !== lat2 > normalizedLng &&
+      latitude < ((lat2 - lat1) * (normalizedLng - lng1)) / dLng + lat1;
 
     if (crosses) {
       inside = !inside;


### PR DESCRIPTION
## Summary

Fixes GPS validation for Pacific island nations (Fiji, Tonga, Samoa) where polygons cross the international date line (±180° longitude).

## Problem

The original validation logic assumed longitudes are always within [-180, 180] and didn't account for wraparound. This caused false negatives for locations near the date line.

## Changes

- **polygon.ts**:
  - Add 
ormalizeLng() to handle longitude wraparound to [-180, 180]
  - Add lngDelta() for shortest signed distance across date line
  - Fix containsPointInPolygon() to use date line-aware calculations
  - Add Pacific island region polygons (Fiji, Tonga, Samoa)

- **distance.ts**:
  - Fix getDistance() Haversine formula to normalize longitudes
  - Ensure shortest path is taken across date line

- **polygon.test.ts**:
  - Add tests for 
ormalizeLng() and lngDelta()
  - Add tests for polygons crossing the date line
  - Add tests for Fiji, Tonga, and Samoa regions

## Test coverage

- Normalization of longitudes beyond ±180
- Shortest delta calculation across date line
- Point-in-polygon for Fiji polygon (crosses 177° to -178°)
- Point-in-polygon for Tonga and Samoa regions

Closes #991