### PR TITLE
docs(frontend): add Storybook setup with component stories

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,19 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  stories: ['../components/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  addons: [
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-interactions',
+  ],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {},
+  },
+  docs: {
+    autodocs: 'tag',
+  },
+};
+
+export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,0 +1,14 @@
+import type { Preview } from '@storybook/react';
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/components/atoms/Button.stories.tsx
+++ b/components/atoms/Button.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'Atoms/Button',
+  component: Button,
+  tags: ['autodocs'],
+  argTypes: {
+    stellar: {
+      control: 'select',
+      options: [
+        'primary',
+        'accent',
+        'cyan',
+        'success',
+        'primary-outline',
+        'accent-outline',
+        'success-outline',
+      ],
+    },
+    width: {
+      control: 'select',
+      options: ['short', 'medium', 'long', 'full', 'auto'],
+    },
+    disabled: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Primary: Story = {
+  args: {
+    children: 'Sponsor Tree',
+    stellar: 'primary',
+  },
+};
+
+export const Accent: Story = {
+  args: {
+    children: 'Donate',
+    stellar: 'accent',
+  },
+};
+
+export const Cyan: Story = {
+  args: {
+    children: 'Learn More',
+    stellar: 'cyan',
+  },
+};
+
+export const Success: Story = {
+  args: {
+    children: 'Verify Planting',
+    stellar: 'success',
+  },
+};
+
+export const PrimaryOutline: Story = {
+  args: {
+    children: 'Cancel',
+    stellar: 'primary-outline',
+  },
+};
+
+export const AccentOutline: Story = {
+  args: {
+    children: 'View Details',
+    stellar: 'accent-outline',
+  },
+};
+
+export const SuccessOutline: Story = {
+  args: {
+    children: 'Download Report',
+    stellar: 'success-outline',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    children: 'Disabled',
+    stellar: 'primary',
+    disabled: true,
+  },
+};
+
+export const FullWidth: Story = {
+  args: {
+    children: 'Full Width Button',
+    stellar: 'primary',
+    width: 'full',
+  },
+};

--- a/components/molecules/FormField.stories.tsx
+++ b/components/molecules/FormField.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { FormField } from './FormField';
+
+const meta: Meta<typeof FormField> = {
+  title: 'Molecules/FormField',
+  component: FormField,
+  tags: ['autodocs'],
+  argTypes: {
+    label: { control: 'text' },
+    helperText: { control: 'text' },
+    errorMessage: { control: 'text' },
+    disabled: { control: 'boolean' },
+    placeholder: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof FormField>;
+
+export const Default: Story = {
+  args: {
+    label: 'Tree Species',
+    placeholder: 'Enter species name',
+  },
+};
+
+export const WithHelperText: Story = {
+  args: {
+    label: 'Carbon Offset (tons)',
+    placeholder: '0.00',
+    helperText: 'Estimated CO₂ offset per year',
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    label: 'Wallet Address',
+    placeholder: 'ST...',
+    errorMessage: 'Invalid Stellar address format',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: 'Project Name',
+    value: 'Amazon Reforestation',
+    disabled: true,
+  },
+};
+
+export const WithValue: Story = {
+  args: {
+    label: 'Donation Amount (XLM)',
+    value: '100',
+    helperText: 'Minimum donation: 10 XLM',
+  },
+};

--- a/components/molecules/ProjectCard/ProjectCard.stories.tsx
+++ b/components/molecules/ProjectCard/ProjectCard.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ProjectCard } from './ProjectCard';
+import type { CarbonProject } from '@/lib/types/carbon';
+
+const meta: Meta<typeof ProjectCard> = {
+  title: 'Molecules/ProjectCard',
+  component: ProjectCard,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ProjectCard>;
+
+const mockProject: CarbonProject = {
+  id: '1',
+  name: 'Amazon Reforestation Initiative',
+  type: 'Reforestation',
+  location: 'Amazon Basin, Brazil',
+  description:
+    'Restoring 10,000 hectares of degraded rainforest through native species planting and community engagement.',
+  pricePerTon: 15,
+  availableSupply: 5000,
+  totalSupply: 10000,
+  isOutOfStock: false,
+  imageUrl: null,
+};
+
+export const Default: Story = {
+  args: {
+    project: mockProject,
+  },
+};
+
+export const MangroveRestoration: Story = {
+  args: {
+    project: {
+      ...mockProject,
+      id: '2',
+      name: 'Sundarbans Mangrove Restoration',
+      type: 'Mangrove Restoration',
+      location: 'Sundarbans, Bangladesh',
+      description:
+        'Restoring coastal mangrove ecosystems to protect against storm surges and sequester carbon.',
+      pricePerTon: 20,
+    },
+  },
+};
+
+export const RenewableEnergy: Story = {
+  args: {
+    project: {
+      ...mockProject,
+      id: '3',
+      name: 'Kenya Solar Farm',
+      type: 'Renewable Energy',
+      location: 'Nairobi, Kenya',
+      description:
+        'Building a 50MW solar farm to provide clean energy to rural communities.',
+      pricePerTon: 12,
+    },
+  },
+};
+
+export const SoldOut: Story = {
+  args: {
+    project: {
+      ...mockProject,
+      id: '4',
+      name: 'Costa Rica Conservation',
+      type: 'Conservation',
+      location: 'Costa Rica',
+      description: 'Protecting 5,000 hectares of primary rainforest.',
+      availableSupply: 0,
+      isOutOfStock: true,
+    },
+  },
+};

--- a/components/ui/Modal.stories.tsx
+++ b/components/ui/Modal.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Modal } from './Modal';
+import { Button } from '@/components/atoms/Button';
+
+const meta: Meta<typeof Modal> = {
+  title: 'UI/Modal',
+  component: Modal,
+  tags: ['autodocs'],
+  argTypes: {
+    open: { control: 'boolean' },
+    title: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Modal>;
+
+const ModalWithState = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button stellar="primary" onClick={() => setOpen(true)}>
+        Open Modal
+      </Button>
+      <Modal open={open} onClose={() => setOpen(false)} title="Sponsor a Tree">
+        <div className="space-y-4">
+          <p>Choose a tree species and quantity to sponsor.</p>
+          <div className="flex gap-2 justify-end">
+            <Button stellar="primary-outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button stellar="success" onClick={() => setOpen(false)}>
+              Confirm Sponsorship
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </>
+  );
+};
+
+export const Interactive: Story = {
+  render: () => <ModalWithState />,
+};
+
+export const OpenWithTitle: Story = {
+  args: {
+    open: true,
+    title: 'Confirm Donation',
+    children: (
+      <div className="space-y-4">
+        <p>You are about to donate 50 XLM to the Amazon Reforestation project.</p>
+        <p className="text-sm text-muted-foreground">
+          This action will transfer tokens from your wallet.
+        </p>
+      </div>
+    ),
+  },
+};
+
+export const OpenWithoutTitle: Story = {
+  args: {
+    open: true,
+    children: (
+      <div className="space-y-4">
+        <p>This modal has no title header.</p>
+      </div>
+    ),
+  },
+};


### PR DESCRIPTION
## Summary

Set up Storybook for documenting and testing reusable UI components in the FarmCredit design system.

## Changes

- **Storybook config**: Added \.storybook/main.ts\ and \.storybook/preview.ts\
- **Button stories** (atoms): 7 Stellar-branded variants — primary, accent, cyan, success, primary-outline, accent-outline, success-outline, plus disabled and full-width
- **FormField stories** (molecules): Default, with helper text, with error state, disabled, with value
- **Modal stories** (ui): Interactive stateful version, open with title, open without title
- **ProjectCard stories** (molecules): Default, Mangrove Restoration, Renewable Energy, Sold Out

## Testing

1. Run \
pm install\ to install Storybook dependencies
2. Run \
pm run storybook\ to launch Storybook dev server
3. Browse components at \http://localhost:6006\
4. Verify all stories render correctly

Closes #988