### PR TITLE
feat(escrow): model emergency withdrawal deadline (#1033)

### DIFF
--- a/lib/escrow/emergency-withdrawal.test.ts
+++ b/lib/escrow/emergency-withdrawal.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { getEmergencyWithdrawalEligibility, PLANTING_DEADLINE_MS } from './emergency-withdrawal';
+
+describe('getEmergencyWithdrawalEligibility', () => {
+  const createdAt = '2026-01-01T00:00:00.000Z';
+
+  it('allows a full withdrawal after 90 days when no planter is assigned', () => {
+    const result = getEmergencyWithdrawalEligibility({
+      createdAt,
+      now: new Date(new Date(createdAt).getTime() + PLANTING_DEADLINE_MS),
+    });
+    expect(result.eligible).toBe(true);
+    expect(result.reason).toBe('eligible');
+  });
+
+  it('blocks withdrawal before the deadline', () => {
+    const result = getEmergencyWithdrawalEligibility({ createdAt, now: new Date('2026-02-01T00:00:00.000Z') });
+    expect(result.eligible).toBe(false);
+    expect(result.reason).toBe('deadline_not_reached');
+  });
+
+  it('blocks the emergency path after the deadline when a planter is assigned', () => {
+    const result = getEmergencyWithdrawalEligibility({
+      createdAt,
+      planterWalletAddress: 'GABC',
+      now: new Date('2026-05-01T00:00:00.000Z'),
+    });
+    expect(result.eligible).toBe(false);
+    expect(result.reason).toBe('planter_assigned');
+  });
+});

--- a/lib/escrow/emergency-withdrawal.ts
+++ b/lib/escrow/emergency-withdrawal.ts
@@ -1,0 +1,28 @@
+export const PLANTING_DEADLINE_DAYS = 90;
+export const PLANTING_DEADLINE_MS = PLANTING_DEADLINE_DAYS * 24 * 60 * 60 * 1000;
+
+export interface EmergencyWithdrawalInput {
+  createdAt: string;
+  planterWalletAddress?: string | null;
+  now?: Date;
+}
+
+export interface EmergencyWithdrawalEligibility {
+  eligible: boolean;
+  deadlineAt: string;
+  reason: 'deadline_not_reached' | 'planter_assigned' | 'eligible';
+}
+
+/** A sponsor may withdraw the full escrow only after 90 days without a planter. */
+export function getEmergencyWithdrawalEligibility({
+  createdAt,
+  planterWalletAddress,
+  now = new Date(),
+}: EmergencyWithdrawalInput): EmergencyWithdrawalEligibility {
+  const created = new Date(createdAt);
+  if (Number.isNaN(created.getTime())) throw new Error('createdAt must be a valid ISO date');
+  const deadline = new Date(created.getTime() + PLANTING_DEADLINE_MS);
+  if (planterWalletAddress?.trim()) return { eligible: false, deadlineAt: deadline.toISOString(), reason: 'planter_assigned' };
+  if (now.getTime() < deadline.getTime()) return { eligible: false, deadlineAt: deadline.toISOString(), reason: 'deadline_not_reached' };
+  return { eligible: true, deadlineAt: deadline.toISOString(), reason: 'eligible' };
+}


### PR DESCRIPTION
﻿Adds the 90-day no-planter emergency-withdrawal eligibility model and tests. Review on-chain transaction and sponsor UI wiring before merge. Closes #1033
