### PR TITLE
feat(faq): add sponsor and planter answers

### DIFF
--- a/lib/faq.test.ts
+++ b/lib/faq.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { faqItems, searchFAQs } from './faq';
+
+describe('sponsor and planter FAQs', () => {
+  it('publishes the three issue-requested questions', () => {
+    expect(faqItems.map((item) => item.question)).toEqual(
+      expect.arrayContaining([
+        'How does verification work?',
+        'Can I donate anonymously?',
+        'How do I withdraw earnings?',
+      ])
+    );
+  });
+
+  it('finds each question by words from the question or answer', () => {
+    expect(searchFAQs('verification').map((item) => item.id)).toContain('sponsors-1');
+    expect(searchFAQs('anonymous').map((item) => item.id)).toContain('sponsors-2');
+    expect(searchFAQs('withdraw').map((item) => item.id)).toContain('planters-1');
+  });
+
+  it('keeps the new entries in the Donations and Credits categories', () => {
+    expect(searchFAQs('How does verification work?')[0]?.category).toBe('Donations');
+    expect(searchFAQs('How do I withdraw earnings?')[0]?.category).toBe('Credits');
+  });
+});

--- a/lib/faq.ts
+++ b/lib/faq.ts
@@ -121,6 +121,27 @@ export const faqItems: FAQItem[] = [
     answer:
       'The Stellar network has 99.99% uptime SLA. In the unlikely event of downtime, transactions queue automatically and complete when service resumes. Your funds are always secure on the blockchain.',
   },
+  {
+    id: 'sponsors-1',
+    category: 'Donations',
+    question: 'How does verification work?',
+    answer:
+      'Planters submit location and milestone evidence through the verification workflow. A verifier reviews the evidence, and only approved milestones release the corresponding escrowed funds. Verification events are recorded for transparent impact tracking.',
+  },
+  {
+    id: 'sponsors-2',
+    category: 'Donations',
+    question: 'Can I donate anonymously?',
+    answer:
+      'Yes. You can sponsor a project from a Stellar wallet without publishing a display name. The transaction remains publicly auditable on Stellar, while the app omits optional profile metadata from public sponsor views.',
+  },
+  {
+    id: 'planters-1',
+    category: 'Credits',
+    question: 'How do I withdraw earnings?',
+    answer:
+      'After a milestone is approved, the escrow releases the corresponding payout to the planter wallet recorded for the project. Connect that wallet, open the project payout history, and use Withdraw when an approved balance is available. Network fees are paid in XLM.',
+  },
 ];
 
 export function getFAQsByCategory(category: FAQItem['category']): FAQItem[] {


### PR DESCRIPTION
## Summary
- Add searchable FAQ entries for verification, anonymous donations, and planter earnings withdrawals.
- Cover the new questions and categories with focused unit tests.

## Validation
- `npx vitest run lib/faq.test.ts` — 3 tests passed.
- Repository-wide TypeScript validation remains blocked by pre-existing syntax errors in unrelated files.

Closes #1027