### PR TITLE
feat(frontend): add toast notification duration customization

### DIFF
--- a/components/providers/ToastProvider.tsx
+++ b/components/providers/ToastProvider.tsx
@@ -4,6 +4,22 @@ import React, { createContext, useState, useCallback } from 'react';
 import { Toast } from '@/components/molecules/Toast';
 import { type ToastMessage, type ToastContextType } from '@/types/sharing';
 
+const DEFAULT_TOAST_DURATION = 5000;
+const MIN_TOAST_DURATION = 2000;
+const MAX_TOAST_DURATION = 10000;
+
+function normalizeToastDuration(duration?: number): number {
+  if (duration === undefined || Number.isNaN(duration)) {
+    return DEFAULT_TOAST_DURATION;
+  }
+
+  if (duration <= 0) {
+    return 0;
+  }
+
+  return Math.min(Math.max(duration, MIN_TOAST_DURATION), MAX_TOAST_DURATION);
+}
+
 export const ToastContext = createContext<ToastContextType | undefined>(undefined);
 
 interface ToastProviderProps {
@@ -14,13 +30,13 @@ export function ToastProvider({ children }: ToastProviderProps): React.ReactElem
   const [toasts, setToasts] = useState<ToastMessage[]>([]);
 
   const addToast = useCallback(
-    (message: string, type: 'success' | 'error' | 'info' = 'info', duration: number = 3000) => {
+    (message: string, type: 'success' | 'error' | 'info' = 'info', duration: number = DEFAULT_TOAST_DURATION) => {
       const id = `toast-${Date.now()}-${Math.random()}`;
       const newToast: ToastMessage = {
         id,
         message,
         type,
-        duration,
+        duration: normalizeToastDuration(duration),
       };
 
       setToasts((prevToasts) => [...prevToasts, newToast]);

--- a/contexts/NotificationContext.tsx
+++ b/contexts/NotificationContext.tsx
@@ -95,6 +95,22 @@ const defaultNotifications: Notification[] = [
   },
 ];
 
+const DEFAULT_TOAST_DURATION = 5000;
+const MIN_TOAST_DURATION = 2000;
+const MAX_TOAST_DURATION = 10000;
+
+export function normalizeToastDuration(duration?: number): number {
+  if (duration === undefined || Number.isNaN(duration)) {
+    return DEFAULT_TOAST_DURATION;
+  }
+
+  if (duration <= 0) {
+    return 0;
+  }
+
+  return Math.min(Math.max(duration, MIN_TOAST_DURATION), MAX_TOAST_DURATION);
+}
+
 const NotificationContext = createContext<NotificationContextValue | undefined>(undefined);
 
 export function NotificationProvider({ children }: { children: ReactNode }): ReactElement {
@@ -125,7 +141,7 @@ export function NotificationProvider({ children }: { children: ReactNode }): Rea
 
   const addToast = useCallback((toast: Omit<ToastNotification, 'id'>) => {
     const id = generateId();
-    const duration = toast.duration ?? 5000;
+    const duration = normalizeToastDuration(toast.duration);
     const newToast: ToastNotification = { ...toast, id, duration };
     setToasts((prev) => [...prev, newToast]);
 

--- a/contexts/ToastContext.tsx
+++ b/contexts/ToastContext.tsx
@@ -9,12 +9,28 @@ export interface ToastAction {
 
 export type ToastType = 'info' | 'success' | 'warning' | 'error' | 'contract';
 
+const DEFAULT_TOAST_DURATION = 5000;
+const MIN_TOAST_DURATION = 2000;
+const MAX_TOAST_DURATION = 10000;
+
+export function normalizeToastDuration(duration?: number): number {
+  if (duration === undefined || Number.isNaN(duration)) {
+    return DEFAULT_TOAST_DURATION;
+  }
+
+  if (duration <= 0) {
+    return 0;
+  }
+
+  return Math.min(Math.max(duration, MIN_TOAST_DURATION), MAX_TOAST_DURATION);
+}
+
 export interface Toast {
   id: string;
   title: string;
   description?: string;
   type?: ToastType;
-  duration?: number; // duration in ms, defaults to 5000
+  duration?: number; // duration in ms, defaults to 5000 and stays within 2000-10000
   action?: ToastAction;
 }
 
@@ -58,7 +74,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   const addToast = useCallback(
     (toastInput: Omit<Toast, 'id'>) => {
       const id = `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
-      const duration = toastInput.duration ?? 5000;
+      const duration = normalizeToastDuration(toastInput.duration);
 
       const newToast: Toast = {
         ...toastInput,

--- a/contexts/__tests__/NotificationContext.test.tsx
+++ b/contexts/__tests__/NotificationContext.test.tsx
@@ -30,6 +30,7 @@ const TestComponent = () => {
     <div>
       <span data-testid="notifications-count">{notifications.length}</span>
       <span data-testid="toasts-count">{toasts.length}</span>
+      <span data-testid="toast-duration">{toasts[0]?.duration ?? 'n/a'}</span>
       <span data-testid="unread-count">{unreadCount}</span>
       <span data-testid="drawer-open">{String(isDrawerOpen)}</span>
       <button
@@ -89,6 +90,12 @@ const TestComponent = () => {
       <button onClick={() => toast.contract('Contract!')} data-testid="toast-contract">
         Contract Toast
       </button>
+      <button
+        onClick={() => addToast({ title: 'Custom', type: 'info', duration: 1500 })}
+        data-testid="add-custom-toast"
+      >
+        Add Custom Toast
+      </button>
     </div>
   );
 };
@@ -124,6 +131,19 @@ describe('NotificationContext', () => {
     fireEvent.click(screen.getByTestId('add-toast'));
 
     expect(screen.getByTestId('toasts-count')).toHaveTextContent('1');
+  });
+
+  it('uses the default duration and clamps custom durations to the supported range', () => {
+    renderWithProvider(<TestComponent />);
+
+    fireEvent.click(screen.getByTestId('add-toast'));
+    expect(screen.getByTestId('toast-duration')).toHaveTextContent('5000');
+
+    fireEvent.click(screen.getByTestId('add-custom-toast'));
+    expect(screen.getByTestId('toast-duration')).toHaveTextContent('2000');
+
+    fireEvent.click(screen.getByTestId('add-custom-toast'));
+    expect(screen.getByTestId('toast-duration')).toHaveTextContent('2000');
   });
 
   it('marks notification as read', () => {

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -5,6 +5,22 @@
 
 export type ToastType = 'success' | 'error' | 'info';
 
+const DEFAULT_TOAST_DURATION = 5000;
+const MIN_TOAST_DURATION = 2000;
+const MAX_TOAST_DURATION = 10000;
+
+export function normalizeToastDuration(duration?: number): number {
+  if (duration === undefined || Number.isNaN(duration)) {
+    return DEFAULT_TOAST_DURATION;
+  }
+
+  if (duration <= 0) {
+    return 0;
+  }
+
+  return Math.min(Math.max(duration, MIN_TOAST_DURATION), MAX_TOAST_DURATION);
+}
+
 interface Toast {
   id: string;
   message: string;
@@ -14,16 +30,21 @@ interface Toast {
 
 const toastCallbacks = new Set<(_toast: Toast) => void>();
 
-export function showToast(message: string, type: ToastType = 'info', duration = 3000): string {
+export function showToast(
+  message: string,
+  type: ToastType = 'info',
+  duration = DEFAULT_TOAST_DURATION
+): string {
+  const normalizedDuration = normalizeToastDuration(duration);
   const id = Math.random().toString(36).substring(7);
-  const toast: Toast = { id, message, type, duration };
+  const toast: Toast = { id, message, type, duration: normalizedDuration };
 
   toastCallbacks.forEach((callback) => callback(toast));
 
-  if (typeof window !== 'undefined') {
+  if (typeof window !== 'undefined' && normalizedDuration > 0) {
     setTimeout(() => {
       dismissToast(id);
-    }, duration);
+    }, normalizedDuration);
   }
 
   return id;


### PR DESCRIPTION
Closes #985

Summary

Adds support for customizing the duration of toast notifications.

Changes
Added an optional duration parameter to toast notifications
Set the default toast duration to 5 seconds
Added support for durations between 2 and 10 seconds
Ensured values outside the supported range are handled appropriately
Updated relevant types and tests