### PR TITLE
fix(contract): reject tree mint at u64::MAX instead of overflowing

### DIFF
--- a/contracts/harvesta-errors/src/lib.rs
+++ b/contracts/harvesta-errors/src/lib.rs
@@ -184,7 +184,7 @@ pub enum NftError {
     SelfTrade = 5,
     /// The seller does not own the token being traded.
     NotTokenOwner = 6,
-    TokenIsSoulbound = 4,
+    TokenIsSoulbound = 7,
 }
 
 #[contracterror]

--- a/contracts/tree-registry/src/lib.rs
+++ b/contracts/tree-registry/src/lib.rs
@@ -17,6 +17,9 @@ pub enum TreeRegistryError {
     InvalidSpeciesName = 90,
     BatchTooLarge = 88,
     BatchSizeMismatch = 89,
+    /// The tree registry has reached the maximum `u64` tree-id capacity and can
+    /// no longer mint new trees.
+    ContractFull = 91,
 }
 
 const ONE_YEAR_SECS: u64 = 31_536_000;
@@ -99,6 +102,16 @@ impl TreeRegistry {
             .instance()
             .get(&symbol_short!("TREECOUNT"))
             .unwrap_or(0);
+
+        // Edge case: the tree ID counter has reached its maximum value. The next
+        // (i.e. this) mint would overflow `u64`. Reject the attempt up front with
+        // a descriptive error instead of panicking on `count + 1`, and surface a
+        // `ContractFull` event so indexers can observe that the registry is full.
+        if count == u64::MAX {
+            env.events().publish((Symbol::new(&env, "ContractFull"), count), ());
+            panic_with_error!(&env, TreeRegistryError::ContractFull);
+        }
+
         let tree_id = count;
 
         let record = TreeRecord {
@@ -965,6 +978,40 @@ mod tests {
         let _id = client.mint_tree(&sponsor, &species, &region, &planter);
 
         assert!(env.events().all().len() > pre_events, "TreeMinted event should be published");
+    }
+
+    #[test]
+    fn test_mint_tree_rejects_at_u64_max() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, TreeRegistry);
+        let client = TreeRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let escrow = Address::generate(&env);
+        let sponsor = Address::generate(&env);
+        let planter = Address::generate(&env);
+
+        client.initialize(&admin, &escrow);
+
+        // Force the tree-id counter to its maximum value to exercise the edge case.
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .set(&symbol_short!("TREECOUNT"), &u64::MAX);
+        });
+
+        let species = String::from_str(&env, "Acacia");
+        let region = String::from_str(&env, "Kaduna");
+
+        // The mint must be rejected with the descriptive `ContractFull` error
+        // instead of panicking on a `u64` overflow.
+        let result = client.try_mint_tree(&sponsor, &species, &region, &planter);
+        assert_eq!(result, Err(Ok(TreeRegistryError::ContractFull)));
+
+        // The counter must remain untouched — no wrap / overflow occurred.
+        assert_eq!(client.tree_count(), u64::MAX);
     }
 
     #[test]


### PR DESCRIPTION
# [BUG] Tree ID overflow — handle edge case when tree ID approaches u64 max

Closes #973 

## Summary

When `TREECOUNT` reaches `u64::MAX`, the next `mint_tree()` call would overflow the `u64` tree-id counter and panic. This PR adds a guard in `mint_tree()` that detects the limit, emits a `ContractFull` event, and returns a descriptive error code instead of panicking — so the contract gracefully rejects any further mint attempts once it is full.

## Changes

### `contracts/tree-registry/src/lib.rs`
- **Added `ContractFull` error code** — `TreeRegistryError::ContractFull = 91` (unique, descriptive code above the existing max).
- **Added the `u64::MAX` guard in `mint_tree()`** — before assigning the next `tree_id`, the function now checks `if count == u64::MAX` and:
  - emits a `ContractFull` event via `env.events().publish(...)`, and
  - returns `panic_with_error!(&env, TreeRegistryError::ContractFull)` instead of reaching the previous `count.checked_add(1).expect("tree count overflow")` panic.
- **Added `test_mint_tree_rejects_at_u64_max`** — forces `TREECOUNT` to `u64::MAX`, asserts the mint is rejected with `ContractFull`, and asserts the counter remains at `u64::MAX` (no wrap / no overflow).

### `contracts/harvesta-errors/src/lib.rs`
- Fixed a **pre-existing duplicate enum discriminant** (`TokenIsSoulbound = 4` collided with `TradeAmountMustBePositive = 4`, an `E0081` fatal error that blocked the entire workspace from compiling) by moving it to `7`.

## Testing

- Added a focused unit test covering the `u64::MAX` edge case; it follows the repo's existing error-assertion pattern (`Err(Ok(Error::...))` via the generated `try_*` client).
- Note: the base `main` branch currently has other pre-existing compile errors in `tree-registry` and `escrow` that are unrelated to this change and block a full local `cargo test`. The changes here are additive and idiomatic with the existing file conventions.

## Acceptance Criteria
- [x] Contract gracefully rejects mint attempt at the `u64` limit (`ContractFull` error instead of panic)
- [x] Error message is descriptive (`TreeRegistryError::ContractFull`)
- [x] `ContractFull` event emitted so the failure is observable by indexers